### PR TITLE
Export operator in Production/Analysis Files

### DIFF
--- a/fetch_raw_data.py
+++ b/fetch_raw_data.py
@@ -19,12 +19,14 @@ Logger.set_project_name("OCHA")
 log = Logger(__name__)
 
 
-def set_operator(user, traced_runs, phone_number_uuid_table):
+def label_somalia_operator(user, traced_runs, phone_number_uuid_table):
     # Set the operator codes for each message.
     uuids = {td["avf_phone_id"] for td in traced_runs}
     uuid_to_phone_lut = phone_number_uuid_table.uuid_to_data_batch(uuids)
     for td in traced_runs:
-        operator_code = PhoneCleaner.clean_operator(uuid_to_phone_lut[td["avf_phone_id"]])
+        operator_raw = uuid_to_phone_lut[td["avf_phone_id"]][:5]  # Returns the country code 252 and the next two digits
+
+        operator_code = PhoneCleaner.clean_operator(operator_raw)
         if operator_code == Codes.NOT_CODED:
             operator_label = CleaningUtils.make_label_from_cleaner_code(
                 CodeSchemes.SOMALIA_OPERATOR,
@@ -37,8 +39,11 @@ def set_operator(user, traced_runs, phone_number_uuid_table):
                 CodeSchemes.SOMALIA_OPERATOR.get_code_with_match_value(operator_code),
                 Metadata.get_call_location()
             )
-        td.append_data({"operator_coded": operator_label.to_dict()},
-                       Metadata(user, Metadata.get_call_location(), TimeUtils.utc_now_as_iso_string()))
+
+        td.append_data({
+            "operator_raw": operator_raw,
+            "operator_coded": operator_label.to_dict()
+        }, Metadata(user, Metadata.get_call_location(), TimeUtils.utc_now_as_iso_string()))
 
 
 def fetch_from_rapid_pro(user, google_cloud_credentials_file_path, raw_data_dir, phone_number_uuid_table,
@@ -96,7 +101,7 @@ def fetch_from_rapid_pro(user, google_cloud_credentials_file_path, raw_data_dir,
             user, raw_runs, raw_contacts, phone_number_uuid_table, rapid_pro_source.test_contact_uuids)
 
         if flow in rapid_pro_source.activation_flow_names:
-            set_operator(user, traced_runs, phone_number_uuid_table)
+            label_somalia_operator(user, traced_runs, phone_number_uuid_table)
 
         log.info(f"Saving {len(raw_runs)} raw runs to {raw_runs_path}...")
         with open(raw_runs_path, "w") as raw_runs_file:

--- a/src/apply_manual_codes.py
+++ b/src/apply_manual_codes.py
@@ -45,6 +45,9 @@ class ApplyManualCodes(object):
     def apply_manual_codes(cls, user, data, coda_input_dir):
         # Merge manually coded data into the cleaned dataset
         for plan in PipelineConfiguration.RQA_CODING_PLANS + PipelineConfiguration.SURVEY_CODING_PLANS:
+            if plan.coda_filename is None:
+                continue
+
             coda_input_path = path.join(coda_input_dir, plan.coda_filename)
 
             for cc in plan.coding_configurations:

--- a/src/auto_code_surveys.py
+++ b/src/auto_code_surveys.py
@@ -40,6 +40,9 @@ class AutoCodeSurveys(object):
         # Output single-scheme answers to coda for manual verification + coding
         IOUtils.ensure_dirs_exist(coda_output_dir)
         for plan in PipelineConfiguration.SURVEY_CODING_PLANS:
+            if plan.coda_filename is None:
+                continue
+
             TracedDataCodaV2IO.compute_message_ids(user, data, plan.raw_field, plan.id_field)
 
             coda_output_path = path.join(coda_output_dir, plan.coda_filename)

--- a/src/lib/pipeline_configuration.py
+++ b/src/lib/pipeline_configuration.py
@@ -35,7 +35,7 @@ class CodingConfiguration(object):
 
 # TODO: Rename CodingPlan to something like DatasetConfiguration?
 class CodingPlan(object):
-    def __init__(self, raw_field, coda_filename, coding_configurations, raw_field_folding_mode, ws_code=None,
+    def __init__(self, raw_field, coding_configurations, raw_field_folding_mode, coda_filename=None, ws_code=None,
                  time_field=None, run_id_field=None, icr_filename=None, id_field=None, code_imputation_function=None):
         self.raw_field = raw_field
         self.time_field = time_field
@@ -103,6 +103,18 @@ class PipelineConfiguration(object):
             return Codes.NOT_CODED
 
     SURVEY_CODING_PLANS = [
+        CodingPlan(raw_field="operator_raw",
+                   coding_configurations=[
+                        CodingConfiguration(
+                            coding_mode=CodingModes.SINGLE,
+                            code_scheme=CodeSchemes.SOMALIA_OPERATOR,
+                            coded_field="operator_coded",
+                            analysis_file_key="operator",
+                            folding_mode=FoldingModes.ASSERT_EQUAL
+                        )
+                   ],
+                   raw_field_folding_mode=FoldingModes.ASSERT_EQUAL),
+
         CodingPlan(raw_field="location_raw",
                    time_field="location_time",
                    coda_filename="location.json",


### PR DESCRIPTION
Review #17 first.

Adding because:
 - it's useful for ROs to see the operator in the production file
 - we include all the other raw data as a check in the analysis file, so it makes sense to include it for operator-derived zone codes too. Of course, "raw" is a bit different here - it's only the first two digits of the phone number (plus country code), which is derivable from the operator code we've shipped in the past.