### PR TITLE
Give each run script a distinct Docker image name

### DIFF
--- a/docker-run-fetch-raw-data.sh
+++ b/docker-run-fetch-raw-data.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-IMAGE_NAME=ocha
+IMAGE_NAME=ocha-fetch-raw-data
 
 while [[ $# -gt 0 ]]; do
     case "$1" in

--- a/docker-run-generate-analysis-graphs.sh
+++ b/docker-run-generate-analysis-graphs.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-IMAGE_NAME=undp-rco
+IMAGE_NAME=ocha-generate-analysis-graphs
 
 while [[ $# -gt 0 ]]; do
     case "$1" in

--- a/docker-run-generate-outputs.sh
+++ b/docker-run-generate-outputs.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-IMAGE_NAME=ocha
+IMAGE_NAME=ocha-generate-outputs
 
 while [[ $# -gt 0 ]]; do
     case "$1" in

--- a/docker-run-upload-logs.sh
+++ b/docker-run-upload-logs.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-IMAGE_NAME=ocha
+IMAGE_NAME=ocha-upload-logs
 
 # Check that the correct number of arguments were provided.
 if [[ $# -ne 6 ]]; then


### PR DESCRIPTION
Previously, it was ok to use the same name because the image was the same for all stages.

However, now that we have build args, each stage may build a slightly different image, so I think it makes sense to tag them differently, especially as this makes working with Docker's cache much easier.