### PR TITLE
Remove commented out channel keys

### DIFF
--- a/src/analysis_file.py
+++ b/src/analysis_file.py
@@ -105,20 +105,7 @@ class AnalysisFile(object):
 
         # Set the list of keys to be exported and how they are to be handled when folding
         export_keys = ["uid", consent_withdrawn_key]
-        bool_keys = [
-            consent_withdrawn_key
-
-            # "sms_ad",
-            # "radio_promo",
-            # "radio_show",
-            # "non_logical_time",
-            # "radio_participation_s02e01",
-            # "radio_participation_s02e02",
-            # "radio_participation_s02e03",
-            # "radio_participation_s02e04",
-            # "radio_participation_s02e05",
-            # "radio_participation_s02e06",
-        ]
+        bool_keys = [consent_withdrawn_key]
         equal_keys = ["uid"]
         concat_keys = []
         matrix_keys = []


### PR DESCRIPTION
This is the third GAP project in a row that hasn't used these.

Not only have they not been useful recently, but channel keys weren't implemented in a way which makes them easily configurable from our configuration files, so we should implement them differently if we need them again.