### PR TITLE
Add STOP code to operator

### DIFF
--- a/code_schemes/somalia_operator.json
+++ b/code_schemes/somalia_operator.json
@@ -86,6 +86,15 @@
       "NumericValue": -30,
       "StringValue": "NC",
       "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-STOP-08b832a8",
+      "CodeType": "Control",
+      "ControlCode": "STOP",
+      "DisplayText": "STOP",
+      "NumericValue": -90,
+      "StringValue": "STOP",
+      "VisibleInCoda": false
     }
   ]
 }


### PR DESCRIPTION
This scheme isn't present in Coda, so I didn't think we needed STOP codes. However, because STOP codes are applied across all code schemes if they exist in one, I think it really should be. 