### PR TITLE
Handle optional coda filenames in WS Correction

### DIFF
--- a/src/ws_correction.py
+++ b/src/ws_correction.py
@@ -24,6 +24,9 @@ class WSCorrection(object):
     def move_wrong_scheme_messages(user, data, coda_input_dir):
         log.info("Importing manually coded Coda files to '_WS' fields...")
         for plan in PipelineConfiguration.RQA_CODING_PLANS + PipelineConfiguration.SURVEY_CODING_PLANS:
+            if plan.coda_filename is None:
+                continue
+
             TracedDataCodaV2IO.compute_message_ids(user, data, plan.raw_field, f"{plan.id_field}_WS")
             with open(f"{coda_input_dir}/{plan.coda_filename}") as f:
                 TracedDataCodaV2IO.import_coda_2_to_traced_data_iterable(

--- a/src/ws_correction.py
+++ b/src/ws_correction.py
@@ -109,7 +109,7 @@ class WSCorrection(object):
             td = group[0]
             survey_moves = dict()  # of source_field -> target_field
             for plan in PipelineConfiguration.SURVEY_CODING_PLANS:
-                if plan.raw_field not in td:
+                if plan.raw_field not in td or plan.coda_filename is None:
                     continue
                 ws_code = CodeSchemes.WS_CORRECT_DATASET.get_code_with_id(td[f"{plan.raw_field}_WS_correct_dataset"]["CodeID"])
                 if ws_code.code_type == "Normal":
@@ -123,7 +123,7 @@ class WSCorrection(object):
             rqa_moves = dict()  # of (index in group, source_field) -> target_field
             for i, td in enumerate(group):
                 for plan in PipelineConfiguration.RQA_CODING_PLANS:
-                    if plan.raw_field not in td:
+                    if plan.raw_field not in td or plan.coda_filename is None:
                         continue
                     ws_code = CodeSchemes.WS_CORRECT_DATASET.get_code_with_id(td[f"{plan.raw_field}_WS_correct_dataset"]["CodeID"])
                     if ws_code.code_type == "Normal":
@@ -136,6 +136,9 @@ class WSCorrection(object):
             # Build a dictionary of the survey fields that haven't been moved, and cleared fields for those which have.
             survey_updates = dict()  # of raw_field -> updated value
             for plan in PipelineConfiguration.SURVEY_CODING_PLANS:
+                if plan.coda_filename is None:
+                    continue
+
                 if plan.raw_field in survey_moves.keys():
                     # Data is moving
                     survey_updates[plan.raw_field] = []
@@ -147,6 +150,9 @@ class WSCorrection(object):
             rqa_updates = []  # of (field, value)
             for i, td in enumerate(group):
                 for plan in PipelineConfiguration.RQA_CODING_PLANS:
+                    if plan.coda_filename is None:
+                        continue
+
                     if plan.raw_field in td:
                         if (i, plan.raw_field) in rqa_moves.keys():
                             # Data is moving


### PR DESCRIPTION
This was made optional in https://github.com/AfricasVoices/Project-OCHA/pull/20, but not tested with ws correction