### PR TITLE
Detect CE in apply_manual_codes.py

### DIFF
--- a/src/apply_manual_codes.py
+++ b/src/apply_manual_codes.py
@@ -3,12 +3,15 @@ from os import path
 
 from core_data_modules.cleaners import Codes
 from core_data_modules.cleaners.cleaning_utils import CleaningUtils
+from core_data_modules.logging import Logger
 from core_data_modules.traced_data import Metadata
 from core_data_modules.traced_data.io import TracedDataCodaV2IO
 
 from src.lib import PipelineConfiguration
 from src.lib.code_schemes import CodeSchemes
 from src.lib.pipeline_configuration import CodingModes
+
+log = Logger(__name__)
 
 
 class ApplyManualCodes(object):
@@ -17,29 +20,56 @@ class ApplyManualCodes(object):
         for td in data:
             coding_error_dict = dict()
             for plan in PipelineConfiguration.RQA_CODING_PLANS + PipelineConfiguration.SURVEY_CODING_PLANS:
-                if f"{plan.raw_field}_WS_correct_dataset" in td:
-                    if td[f"{plan.raw_field}_WS_correct_dataset"]["CodeID"] == \
-                            CodeSchemes.WS_CORRECT_DATASET.get_code_with_control_code(Codes.CODING_ERROR).code_id:
-                        for cc in plan.coding_configurations:
-                            if cc.coding_mode == CodingModes.SINGLE:
-                                coding_error_dict[cc.coded_field] = \
-                                    CleaningUtils.make_label_from_cleaner_code(
-                                        cc.code_scheme,
-                                        cc.code_scheme.get_code_with_control_code(Codes.CODING_ERROR),
-                                        Metadata.get_call_location()
-                                    ).to_dict()
-                            else:
-                                assert cc.coding_mode == CodingModes.MULTIPLE
-                                coding_error_dict[cc.coded_field] = [
-                                    CleaningUtils.make_label_from_cleaner_code(
-                                        cc.code_scheme,
-                                        cc.code_scheme.get_code_with_control_code(Codes.CODING_ERROR),
-                                        Metadata.get_call_location()
-                                    ).to_dict()
-                                ]
+                rqa_codes = []
+                for cc in plan.coding_configurations:
+                    if cc.coding_mode == CodingModes.SINGLE:
+                        if cc.coded_field in td:
+                            label = td[cc.coded_field]
+                            rqa_codes.append(cc.code_scheme.get_code_with_id(label["CodeID"]))
+                    else:
+                        assert cc.coding_mode == CodingModes.MULTIPLE
+                        for label in td.get(cc.coded_field, []):
+                            rqa_codes.append(cc.code_scheme.get_code_with_id(label["CodeID"]))
 
-            td.append_data(coding_error_dict,
-                           Metadata(user, Metadata.get_call_location(), time.time()))
+                has_ws_code_in_code_scheme = False
+                for code in rqa_codes:
+                    if code.control_code == Codes.WRONG_SCHEME:
+                        has_ws_code_in_code_scheme = True
+
+                has_ws_code_in_ws_scheme = False
+                if f"{plan.raw_field}_WS_correct_dataset" in td:
+                    ws_code = CodeSchemes.WS_CORRECT_DATASET.get_code_with_id(
+                        td[f"{plan.raw_field}_WS_correct_dataset"]["CodeID"])
+                    has_ws_code_in_ws_scheme = ws_code.code_type == "Normal" or ws_code.control_code == Codes.NOT_CODED
+
+                if has_ws_code_in_code_scheme != has_ws_code_in_ws_scheme:
+                    log.warning(f"Coding Error: {plan.raw_field}: {td[plan.raw_field]}")
+                    coding_error_dict[f"{plan.raw_field}_WS_correct_dataset"] = \
+                        CleaningUtils.make_label_from_cleaner_code(
+                            CodeSchemes.WS_CORRECT_DATASET,
+                            CodeSchemes.WS_CORRECT_DATASET.get_code_with_control_code(Codes.CODING_ERROR),
+                            Metadata.get_call_location(),
+                        ).to_dict()
+
+                    for cc in plan.coding_configurations:
+                        if cc.coding_mode == CodingModes.SINGLE:
+                            coding_error_dict[cc.coded_field] = \
+                                CleaningUtils.make_label_from_cleaner_code(
+                                    cc.code_scheme,
+                                    cc.code_scheme.get_code_with_control_code(Codes.CODING_ERROR),
+                                    Metadata.get_call_location()
+                                ).to_dict()
+                        else:
+                            assert cc.coding_mode == CodingModes.MULTIPLE
+                            coding_error_dict[cc.coded_field] = [
+                                CleaningUtils.make_label_from_cleaner_code(
+                                    cc.code_scheme,
+                                    cc.code_scheme.get_code_with_control_code(Codes.CODING_ERROR),
+                                    Metadata.get_call_location()
+                                ).to_dict()
+                            ]
+
+            td.append_data(coding_error_dict, Metadata(user, Metadata.get_call_location(), time.time()))
 
     @classmethod
     def apply_manual_codes(cls, user, data, coda_input_dir):
@@ -65,6 +95,19 @@ class ApplyManualCodes(object):
                 finally:
                     if f is not None:
                         f.close()
+
+            f = None
+            try:
+                if path.exists(coda_input_path):
+                    f = open(coda_input_path, "r")
+
+                TracedDataCodaV2IO.import_coda_2_to_traced_data_iterable(
+                    user, data, plan.id_field,
+                    {f"{plan.raw_field}_WS_correct_dataset": CodeSchemes.WS_CORRECT_DATASET}, f
+                )
+            finally:
+                if f is not None:
+                    f.close()
 
         # Label data for which there is no response as TRUE_MISSING.
         # Label data for which the response is the empty string as NOT_CODED.

--- a/src/apply_manual_codes.py
+++ b/src/apply_manual_codes.py
@@ -37,14 +37,14 @@ class ApplyManualCodes(object):
                         has_ws_code_in_code_scheme = True
 
                 has_ws_code_in_ws_scheme = False
-                if f"{plan.raw_field}_WS_correct_dataset" in td:
+                if f"{plan.raw_field}_correct_dataset" in td:
                     ws_code = CodeSchemes.WS_CORRECT_DATASET.get_code_with_id(
-                        td[f"{plan.raw_field}_WS_correct_dataset"]["CodeID"])
+                        td[f"{plan.raw_field}_correct_dataset"]["CodeID"])
                     has_ws_code_in_ws_scheme = ws_code.code_type == "Normal" or ws_code.control_code == Codes.NOT_CODED
 
                 if has_ws_code_in_code_scheme != has_ws_code_in_ws_scheme:
                     log.warning(f"Coding Error: {plan.raw_field}: {td[plan.raw_field]}")
-                    coding_error_dict[f"{plan.raw_field}_WS_correct_dataset"] = \
+                    coding_error_dict[f"{plan.raw_field}_correct_dataset"] = \
                         CleaningUtils.make_label_from_cleaner_code(
                             CodeSchemes.WS_CORRECT_DATASET,
                             CodeSchemes.WS_CORRECT_DATASET.get_code_with_control_code(Codes.CODING_ERROR),
@@ -103,7 +103,7 @@ class ApplyManualCodes(object):
 
                 TracedDataCodaV2IO.import_coda_2_to_traced_data_iterable(
                     user, data, plan.id_field,
-                    {f"{plan.raw_field}_WS_correct_dataset": CodeSchemes.WS_CORRECT_DATASET}, f
+                    {f"{plan.raw_field}_correct_dataset": CodeSchemes.WS_CORRECT_DATASET}, f
                 )
             finally:
                 if f is not None:


### PR DESCRIPTION
Previously this was only done in ws_correction.py. However:
 - imputation of CE wasn't working for RQAs which were WS but with a coding error e.g. WS in the main code schemes but no code in the WS - Correct Dataset scheme. Doing it here means that CEs will now carry through to analysis as expected rather than occasionally being 'converted back' to WS.
 - that means we can't detect the most common class of coding errors until ws_correction is enabled. Putting the logic into apply manual codes means we see them as soon as analysis files start to be generated.