### PR TITLE
Move ConsentUtils to its own file

### DIFF
--- a/src/analysis_file.py
+++ b/src/analysis_file.py
@@ -7,88 +7,8 @@ from core_data_modules.traced_data.io import TracedDataCSVIO
 from core_data_modules.traced_data.util import FoldTracedData
 from core_data_modules.util import TimeUtils
 
-from src.lib import PipelineConfiguration
+from src.lib import PipelineConfiguration, ConsentUtils
 from src.lib.pipeline_configuration import CodingModes, FoldingModes
-
-
-class ConsentUtils(object):
-    # TODO: This used to be in Core but has been duplicated then modified here in order to test the updates
-    #       needed to support Labels instead of strings.
-    @staticmethod
-    def td_has_stop_code(td, coding_plans):
-        """
-        Returns whether any of the values for the given keys are Codes.STOP in the given TracedData object.
-
-        :param td: TracedData object to search for stop codes.
-        :type td: TracedData
-        :param coding_plans:
-        :type coding_plans: iterable of CodingPlan
-        :return: Whether td contains Codes.STOP in any of the keys in 'keys'.
-        :rtype: bool
-        """
-        for plan in coding_plans:
-            for cc in plan.coding_configurations:
-                if cc.coding_mode == CodingModes.SINGLE:
-                    if cc.code_scheme.get_code_with_id(td[cc.coded_field]["CodeID"]).control_code == Codes.STOP:
-                        return True
-                else:
-                    if td[f"{cc.analysis_file_key}{Codes.STOP}"] == Codes.MATRIX_1:
-                        return True
-        return False
-
-    @classmethod
-    def determine_consent_withdrawn(cls, user, data, coding_plans, withdrawn_key="consent_withdrawn"):
-        """
-        Determines whether consent has been withdrawn, by searching for Codes.STOP in the given list of keys.
-
-        TracedData objects where a stop code is found will have the key-value pair <withdrawn_key>: Codes.TRUE
-        appended. Objects where a stop code is not found are not modified.
-
-        Note that this does not actually set any other keys to Codes.STOP. Use Consent.set_stopped for this purpose.
-
-        :param user: Identifier of the user running this program, for TracedData Metadata.
-        :type user: str
-        :param data: TracedData objects to determine consent for.
-        :type data: iterable of TracedData
-        :param coding_plans:
-        :type coding_plans: iterable of CodingPlan
-        :param withdrawn_key: Name of key to use for the consent withdrawn field.
-        :type withdrawn_key: str
-        """
-        stopped_uids = set()
-        for td in data:
-            if cls.td_has_stop_code(td, coding_plans):
-                stopped_uids.add(td["uid"])
-
-        for td in data:
-            if td["uid"] in stopped_uids:
-                td.append_data(
-                    {withdrawn_key: Codes.TRUE},
-                    Metadata(user, Metadata.get_call_location(), time.time())
-                )
-
-    @staticmethod
-    def set_stopped(user, data, withdrawn_key="consent_withdrawn", additional_keys=None):
-        """
-        For each TracedData object in an iterable whose 'withdrawn_key' is Codes.True, sets every other key to
-        Codes.STOP. If there is no withdrawn_key or the value is not Codes.True, that TracedData object is not modified.
-
-        :param user: Identifier of the user running this program, for TracedData Metadata.
-        :type user: str
-        :param data: TracedData objects to set to stopped if consent has been withdrawn.
-        :type data: iterable of TracedData
-        :param withdrawn_key: Key in each TracedData object which indicates whether consent has been withdrawn.
-        :type withdrawn_key: str
-        :param additional_keys: Additional keys to set to 'STOP' (e.g. keys not already in some TracedData objects)
-        :type additional_keys: list of str | None
-        """
-        if additional_keys is None:
-            additional_keys = []
-
-        for td in data:
-            if td.get(withdrawn_key) == Codes.TRUE:
-                stop_dict = {key: Codes.STOP for key in list(td.keys()) + additional_keys if key != withdrawn_key}
-                td.append_data(stop_dict, Metadata(user, Metadata.get_call_location(), time.time()))
 
 
 class AnalysisFile(object):

--- a/src/lib/__init__.py
+++ b/src/lib/__init__.py
@@ -1,4 +1,5 @@
 from .code_schemes import CodeSchemes
+from .consent_utils import ConsentUtils
 from .icr_tools import ICRTools
 from .message_filters import MessageFilters
 from .pipeline_configuration import PipelineConfiguration

--- a/src/lib/consent_utils.py
+++ b/src/lib/consent_utils.py
@@ -1,0 +1,84 @@
+import time
+
+from core_data_modules.cleaners import Codes
+from core_data_modules.traced_data import Metadata
+
+from src.lib.pipeline_configuration import CodingModes
+
+
+class ConsentUtils(object):
+    @staticmethod
+    def td_has_stop_code(td, coding_plans):
+        """
+        Returns whether any of the values for the given keys are Codes.STOP in the given TracedData object.
+
+        :param td: TracedData object to search for stop codes.
+        :type td: TracedData
+        :param coding_plans:
+        :type coding_plans: iterable of CodingPlan
+        :return: Whether td contains Codes.STOP in any of the keys in 'keys'.
+        :rtype: bool
+        """
+        for plan in coding_plans:
+            for cc in plan.coding_configurations:
+                if cc.coding_mode == CodingModes.SINGLE:
+                    if cc.code_scheme.get_code_with_id(td[cc.coded_field]["CodeID"]).control_code == Codes.STOP:
+                        return True
+                else:
+                    if td[f"{cc.analysis_file_key}{Codes.STOP}"] == Codes.MATRIX_1:
+                        return True
+        return False
+
+    @classmethod
+    def determine_consent_withdrawn(cls, user, data, coding_plans, withdrawn_key="consent_withdrawn"):
+        """
+        Determines whether consent has been withdrawn, by searching for Codes.STOP in the given list of keys.
+
+        TracedData objects where a stop code is found will have the key-value pair <withdrawn_key>: Codes.TRUE
+        appended. Objects where a stop code is not found are not modified.
+
+        Note that this does not actually set any other keys to Codes.STOP. Use Consent.set_stopped for this purpose.
+
+        :param user: Identifier of the user running this program, for TracedData Metadata.
+        :type user: str
+        :param data: TracedData objects to determine consent for.
+        :type data: iterable of TracedData
+        :param coding_plans:
+        :type coding_plans: iterable of CodingPlan
+        :param withdrawn_key: Name of key to use for the consent withdrawn field.
+        :type withdrawn_key: str
+        """
+        stopped_uids = set()
+        for td in data:
+            if cls.td_has_stop_code(td, coding_plans):
+                stopped_uids.add(td["uid"])
+
+        for td in data:
+            if td["uid"] in stopped_uids:
+                td.append_data(
+                    {withdrawn_key: Codes.TRUE},
+                    Metadata(user, Metadata.get_call_location(), time.time())
+                )
+
+    @staticmethod
+    def set_stopped(user, data, withdrawn_key="consent_withdrawn", additional_keys=None):
+        """
+        For each TracedData object in an iterable whose 'withdrawn_key' is Codes.True, sets every other key to
+        Codes.STOP. If there is no withdrawn_key or the value is not Codes.True, that TracedData object is not modified.
+
+        :param user: Identifier of the user running this program, for TracedData Metadata.
+        :type user: str
+        :param data: TracedData objects to set to stopped if consent has been withdrawn.
+        :type data: iterable of TracedData
+        :param withdrawn_key: Key in each TracedData object which indicates whether consent has been withdrawn.
+        :type withdrawn_key: str
+        :param additional_keys: Additional keys to set to 'STOP' (e.g. keys not already in some TracedData objects)
+        :type additional_keys: list of str | None
+        """
+        if additional_keys is None:
+            additional_keys = []
+
+        for td in data:
+            if td.get(withdrawn_key) == Codes.TRUE:
+                stop_dict = {key: Codes.STOP for key in list(td.keys()) + additional_keys if key != withdrawn_key}
+                td.append_data(stop_dict, Metadata(user, Metadata.get_call_location(), time.time()))


### PR DESCRIPTION
This used to be in src/lib. Then it was moved to Core, which wasn't actually a good place for it, so when the pipeline was updated to support Coda 2 it was 'temporarily' copied back into analysis_file.py, then copied from project to project. This PR moves it back to src/lib, where it belongs.