### PR TITLE
Read sent_on key from PipelineConfiguration

### DIFF
--- a/src/auto_code.py
+++ b/src/auto_code.py
@@ -12,7 +12,6 @@ log = Logger(__name__)
 
 
 class AutoCode(object):
-    SENT_ON_KEY = "sent_on"
     NOISE_KEY = "noise"
     ICR_MESSAGES_COUNT = 200
     ICR_SEED = 0
@@ -67,7 +66,8 @@ class AutoCode(object):
                                                     [plan.raw_field for plan in PipelineConfiguration.RQA_CODING_PLANS])
 
         # Filter out runs sent outwith the project start and end dates
-        data = MessageFilters.filter_time_range(data, cls.SENT_ON_KEY, project_start_date, project_end_date)
+        time_keys = {plan.time_field for plan in PipelineConfiguration.RQA_CODING_PLANS}
+        data = MessageFilters.filter_time_range(data, time_keys, project_start_date, project_end_date)
 
         return data
 

--- a/src/lib/message_filters.py
+++ b/src/lib/message_filters.py
@@ -57,15 +57,16 @@ class MessageFilters(object):
         return filtered
 
     @staticmethod
-    def filter_time_range(messages, time_key, start_time_inclusive, end_time_inclusive):
+    def filter_time_range(messages, time_keys, start_time_inclusive, end_time_inclusive):
         """
         Filters a list of messages for messages received within the given time range.
 
         :param messages: List of message objects to filter.
         :type messages: list of TracedData
-        :param time_key: Key in each TracedData object that contains the time the message was sent.
-                         The values must be strings in ISO 8601 format.
-        :type time_key: str
+        :param time_keys: Keys in each TracedData object that contain the time the message was sent.
+                          Each TracedData should have exactly one match for each key.
+                          The values must be strings in ISO 8601 format.
+        :type time_keys: set of str
         :param start_time_inclusive: Inclusive start time of the time range to keep.
                            Messages sent before this time will be dropped. 
         :type start_time_inclusive: datetime.datetime
@@ -75,12 +76,33 @@ class MessageFilters(object):
         :return: Filtered list.
         :rtype: list of TracedData
         """
+        # De-duplicate time_keys
+        time_keys = set(time_keys)
+
         log.debug(f"Filtering out messages sent outside the time range "
-                  f"{start_time_inclusive.isoformat()} to {end_time_inclusive.isoformat()}...")
-        filtered = [td for td in messages if start_time_inclusive <= isoparse(td[time_key]) < end_time_inclusive]
+                  f"{start_time_inclusive.isoformat()} to {end_time_inclusive.isoformat()} "
+                  f"for time keys {time_keys}...")
+
+        # Validate the input data
+        for td in messages:
+            matching_time_keys = 0
+            for time_key in time_keys:
+                if time_key in td:
+                    matching_time_keys += 1
+            assert matching_time_keys == 1, matching_time_keys
+
+        # Perform the actual filtering
+        filtered = []
+        for td in messages:
+            for time_key in time_keys:
+                if time_key in td and start_time_inclusive <= isoparse(td[time_key]) < end_time_inclusive:
+                    filtered.append(td)
+                    break
+
         log.info(f"Filtered out messages sent outside the time range "
                  f"{start_time_inclusive.isoformat()} to {end_time_inclusive.isoformat()}. "
                  f"Returning {len(filtered)}/{len(messages)} messages.")
+
         return filtered
 
     @staticmethod

--- a/src/lib/message_filters.py
+++ b/src/lib/message_filters.py
@@ -77,7 +77,8 @@ class MessageFilters(object):
         :rtype: list of TracedData
         """
         # De-duplicate time_keys
-        time_keys = set(time_keys)
+        assert isinstance(time_keys, set)
+        time_keys = time_keys
 
         log.debug(f"Filtering out messages sent outside the time range "
                   f"{start_time_inclusive.isoformat()} to {end_time_inclusive.isoformat()} "

--- a/src/translate_rapid_pro_keys.py
+++ b/src/translate_rapid_pro_keys.py
@@ -60,7 +60,7 @@ class TranslateRapidProKeys(object):
         :param range_end: End datetime for the time range to remap radio show messages from, exclusive.
                           If None, defaults to the end of time.
         :type range_end: datetime | None
-        :param time_to_adjust_to: Datetime to assign to the 'sent_on' field of re-mapped shows.
+        :param time_to_adjust_to: Datetime to assign to the `time_key` field of re-mapped shows.
                                   If None, re-mapped shows will not have timestamps re-adjusted.
         :type time_to_adjust_to: datetime | None
         """

--- a/src/ws_correction.py
+++ b/src/ws_correction.py
@@ -228,12 +228,9 @@ class WSCorrection(object):
 
             # For each rqa message, create a copy of this td, append the rqa message, and add this to the
             # list of TracedData.
+            raw_field_to_rqa_plan_map = {plan.raw_field: plan for plan in PipelineConfiguration.RQA_CODING_PLANS}
             for target_field, update in rqa_updates:
-                for plan in PipelineConfiguration.RQA_CODING_PLANS:
-                    if plan.raw_field == update.source:
-                        break
-                else:
-                    assert False, f"No matching RQA plan found for source {update.source}"
+                plan = raw_field_to_rqa_plan_map[update.source]
 
                 rqa_dict = {
                     target_field: update.message,

--- a/src/ws_correction.py
+++ b/src/ws_correction.py
@@ -229,9 +229,15 @@ class WSCorrection(object):
             # For each rqa message, create a copy of this td, append the rqa message, and add this to the
             # list of TracedData.
             for target_field, update in rqa_updates:
+                for plan in PipelineConfiguration.RQA_CODING_PLANS:
+                    if plan.raw_field == update.source:
+                        break
+                else:
+                    assert False, f"No matching RQA plan found for source {update.source}"
+
                 rqa_dict = {
                     target_field: update.message,
-                    "sent_on": update.sent_on,
+                    plan.time_field: update.sent_on,
                     f"{target_field}_source": update.source
                 }
 

--- a/src/ws_correction.py
+++ b/src/ws_correction.py
@@ -13,9 +13,9 @@ log = Logger(__name__)
 
 
 class _WSUpdate(object):
-    def __init__(self, message, sent_on, source):
+    def __init__(self, message, timestamp, source):
         self.message = message
-        self.sent_on = sent_on
+        self.timestamp = timestamp
         self.source = source
 
 
@@ -207,7 +207,7 @@ class WSCorrection(object):
 
                     if len(plan_updates) > 0:
                         flattened_survey_updates[plan.raw_field] = "; ".join([u.message for u in plan_updates])
-                        flattened_survey_updates[plan.time_field] = sorted([u.sent_on for u in plan_updates])[0]
+                        flattened_survey_updates[plan.time_field] = sorted([u.timestamp for u in plan_updates])[0]
                         flattened_survey_updates[f"{plan.raw_field}_source"] = "; ".join([u.source for u in plan_updates])
                     else:
                         flattened_survey_updates[plan.raw_field] = None
@@ -237,7 +237,7 @@ class WSCorrection(object):
 
                 rqa_dict = {
                     target_field: update.message,
-                    plan.time_field: update.sent_on,
+                    plan.time_field: update.timestamp,
                     f"{target_field}_source": update.source
                 }
 


### PR DESCRIPTION
"sent_on" used to be hard-coded in all sorts of places in the pipeline. This PR removes the hardcoding, such that it only needs to be defined in PipelineConfiguration. It even uses existing definitions, so there isn't actually any new configuration anywhere :)

(as a side-effect, we can now set a different time_key per RQA, if desired, although this will still break for recovered datasets. This will be much easier to fix after #50 is merged).