### PR TITLE
Generate participation graphs from the same aggregated source as the CSV

### DIFF
--- a/generate_analysis_graphs.py
+++ b/generate_analysis_graphs.py
@@ -148,7 +148,7 @@ if __name__ == "__main__":
             writer.writerow(row)
             
     log.info("Graphing the per-episode engagement counts...")
-    # Graph the number of messages in each show
+    # Graph the number of messages in each episode
     altair.Chart(
         altair.Data(values=[{"episode": x["Episode"], "count": x["Total Messages"]}
                             for x in engagement_counts.values() if x["Episode"] != "Total"])

--- a/generate_analysis_graphs.py
+++ b/generate_analysis_graphs.py
@@ -150,21 +150,21 @@ if __name__ == "__main__":
     log.info("Graphing the per-episode engagement counts...")
     # Graph the number of messages in each show
     altair.Chart(
-        altair.Data(values=[{"show": x["Episode"], "count": x["Total Participants"]}
+        altair.Data(values=[{"episode": x["Episode"], "count": x["Total Participants"]}
                             for x in engagement_counts.values() if x["Episode"] != "Total"])
     ).mark_bar().encode(
-        x=altair.X("show:N", title="Show"),
+        x=altair.X("episode:N", title="Episode"),
         y=altair.Y("count:Q", title="Number of Individuals")
     ).properties(
-        title="Individuals per Show"
-    ).save(f"{output_dir}/individuals_per_show.png", scale_factor=IMG_SCALE_FACTOR)
+        title="Individuals per episode"
+    ).save(f"{output_dir}/individuals_per_episode.png", scale_factor=IMG_SCALE_FACTOR)
 
-    # Graph the number of individuals in each show
+    # Graph the number of individuals in each episode
     altair.Chart(
-        altair.Data(values=[{"show": x["Episode"], "count": x["Total Participants"]}
+        altair.Data(values=[{"episode": x["Episode"], "count": x["Total Participants"]}
                             for x in engagement_counts.values() if x["Episode"] != "Total"])
     ).mark_bar().encode(
-        x=altair.X("show:N", title="Show"),
+        x=altair.X("episode:N", title="Episode"),
         y=altair.Y("count:Q", title="Number of Individuals")
     ).properties(
         title="Individuals per Show"

--- a/generate_analysis_graphs.py
+++ b/generate_analysis_graphs.py
@@ -156,7 +156,7 @@ if __name__ == "__main__":
         x=altair.X("episode:N", title="Episode"),
         y=altair.Y("count:Q", title="Number of Messages")
     ).properties(
-        title="Messages per episode"
+        title="Messages per Episode"
     ).save(f"{output_dir}/messages_per_episode.png", scale_factor=IMG_SCALE_FACTOR)
 
     # Graph the number of individuals in each episode
@@ -167,8 +167,8 @@ if __name__ == "__main__":
         x=altair.X("episode:N", title="Episode"),
         y=altair.Y("count:Q", title="Number of Individuals")
     ).properties(
-        title="Individuals per Show"
-    ).save(f"{output_dir}/individuals_per_show.png", scale_factor=IMG_SCALE_FACTOR)
+        title="Individuals per Episode"
+    ).save(f"{output_dir}/individuals_per_episode.png", scale_factor=IMG_SCALE_FACTOR)
 
     # Plot the per-season distribution of responses for each survey question, per individual
     for plan in PipelineConfiguration.RQA_CODING_PLANS + PipelineConfiguration.SURVEY_CODING_PLANS:

--- a/generate_analysis_graphs.py
+++ b/generate_analysis_graphs.py
@@ -165,10 +165,10 @@ if __name__ == "__main__":
                             for x in engagement_counts.values() if x["Episode"] != "Total"])
     ).mark_bar().encode(
         x=altair.X("episode:N", title="Episode"),
-        y=altair.Y("count:Q", title="Number of Individuals")
+        y=altair.Y("count:Q", title="Number of Participants")
     ).properties(
-        title="Individuals per Episode"
-    ).save(f"{output_dir}/individuals_per_episode.png", scale_factor=IMG_SCALE_FACTOR)
+        title="Participants per Episode"
+    ).save(f"{output_dir}/participants_per_episode.png", scale_factor=IMG_SCALE_FACTOR)
 
     # Plot the per-season distribution of responses for each survey question, per individual
     for plan in PipelineConfiguration.RQA_CODING_PLANS + PipelineConfiguration.SURVEY_CODING_PLANS:

--- a/generate_analysis_graphs.py
+++ b/generate_analysis_graphs.py
@@ -150,14 +150,14 @@ if __name__ == "__main__":
     log.info("Graphing the per-episode engagement counts...")
     # Graph the number of messages in each show
     altair.Chart(
-        altair.Data(values=[{"episode": x["Episode"], "count": x["Total Participants"]}
+        altair.Data(values=[{"episode": x["Episode"], "count": x["Total Messages"]}
                             for x in engagement_counts.values() if x["Episode"] != "Total"])
     ).mark_bar().encode(
         x=altair.X("episode:N", title="Episode"),
-        y=altair.Y("count:Q", title="Number of Individuals")
+        y=altair.Y("count:Q", title="Number of Messages")
     ).properties(
-        title="Individuals per episode"
-    ).save(f"{output_dir}/individuals_per_episode.png", scale_factor=IMG_SCALE_FACTOR)
+        title="Messages per episode"
+    ).save(f"{output_dir}/messages_per_episode.png", scale_factor=IMG_SCALE_FACTOR)
 
     # Graph the number of individuals in each episode
     altair.Chart(

--- a/generate_analysis_graphs.py
+++ b/generate_analysis_graphs.py
@@ -72,28 +72,6 @@ if __name__ == "__main__":
         individuals = TracedDataJsonIO.import_jsonl_to_traced_data_iterable(f)
     log.info(f"Loaded {len(individuals)} individuals")
 
-    # Compute the number of messages in each show and graph
-    log.info(f"Graphing the number of messages received in response to each show...")
-    messages_per_show = OrderedDict()  # Of radio show index to messages count
-    for plan in PipelineConfiguration.RQA_CODING_PLANS:
-        messages_per_show[plan.raw_field] = 0
-
-    for msg in messages:
-        for plan in PipelineConfiguration.RQA_CODING_PLANS:
-            if msg.get(plan.raw_field, "") != "" and msg["consent_withdrawn"] == "false":
-                messages_per_show[plan.raw_field] += 1
-
-    chart = altair.Chart(
-        altair.Data(values=[{"show": k, "count": v} for k, v in messages_per_show.items()])
-    ).mark_bar().encode(
-        x=altair.X("show:N", title="Show", sort=list(messages_per_show.keys())),
-        y=altair.Y("count:Q", title="Number of Messages")
-    ).properties(
-        title="Messages per Show"
-    )
-    chart.save(f"{output_dir}/messages_per_show.html")
-    chart.save(f"{output_dir}/messages_per_show.png", scale_factor=IMG_SCALE_FACTOR)
-
     # Compute the number of messages, individuals, and relevant messages per episode and overall.
     log.info("Computing the per-episode and per-season engagement counts...")
     engagement_counts = OrderedDict()
@@ -169,30 +147,28 @@ if __name__ == "__main__":
         for row in engagement_counts.values():
             writer.writerow(row)
             
-    # TODO: Update the graph generation code to use the engagement_counts dict rather than performing additional local
-    #       derivations of the participation figures
-
-    # Compute the number of individuals in each show and graph
-    log.info(f"Graphing the number of individuals who responded to each show...")
-    individuals_per_show = OrderedDict()  # Of radio show index to individuals count
-    for plan in PipelineConfiguration.RQA_CODING_PLANS:
-        individuals_per_show[plan.raw_field] = 0
-
-    for ind in individuals:
-        for plan in PipelineConfiguration.RQA_CODING_PLANS:
-            if ind.get(plan.raw_field, "") != "" and ind["consent_withdrawn"] == "false":
-                individuals_per_show[plan.raw_field] += 1
-
-    chart = altair.Chart(
-        altair.Data(values=[{"show": k, "count": v} for k, v in individuals_per_show.items()])
+    log.info("Graphing the per-episode engagement counts...")
+    # Graph the number of messages in each show
+    altair.Chart(
+        altair.Data(values=[{"show": x["Episode"], "count": x["Total Participants"]}
+                            for x in engagement_counts.values() if x["Episode"] != "Total"])
     ).mark_bar().encode(
-        x=altair.X("show:N", title="Show", sort=list(individuals_per_show.keys())),
+        x=altair.X("show:N", title="Show"),
         y=altair.Y("count:Q", title="Number of Individuals")
     ).properties(
         title="Individuals per Show"
-    )
-    chart.save(f"{output_dir}/individuals_per_show.html")
-    chart.save(f"{output_dir}/individuals_per_show.png", scale_factor=IMG_SCALE_FACTOR)
+    ).save(f"{output_dir}/individuals_per_show.png", scale_factor=IMG_SCALE_FACTOR)
+
+    # Graph the number of individuals in each show
+    altair.Chart(
+        altair.Data(values=[{"show": x["Episode"], "count": x["Total Participants"]}
+                            for x in engagement_counts.values() if x["Episode"] != "Total"])
+    ).mark_bar().encode(
+        x=altair.X("show:N", title="Show"),
+        y=altair.Y("count:Q", title="Number of Individuals")
+    ).properties(
+        title="Individuals per Show"
+    ).save(f"{output_dir}/individuals_per_show.png", scale_factor=IMG_SCALE_FACTOR)
 
     # Plot the per-season distribution of responses for each survey question, per individual
     for plan in PipelineConfiguration.RQA_CODING_PLANS + PipelineConfiguration.SURVEY_CODING_PLANS:

--- a/generate_analysis_graphs.py
+++ b/generate_analysis_graphs.py
@@ -159,7 +159,7 @@ if __name__ == "__main__":
         title="Messages per Episode"
     ).save(f"{output_dir}/messages_per_episode.png", scale_factor=IMG_SCALE_FACTOR)
 
-    # Graph the number of individuals in each episode
+    # Graph the number of participants in each episode
     altair.Chart(
         altair.Data(values=[{"episode": x["Episode"], "count": x["Total Participants"]}
                             for x in engagement_counts.values() if x["Episode"] != "Total"])


### PR DESCRIPTION
Review #57 first.

Previously the logic for computing engagement was duplicated for the CSV and for the graphs. This update means both the CSVs and graphs are generated from the same logic, which is only run once.