### PR TITLE
Don't overwrite older demog answers with None

### DIFF
--- a/src/translate_rapid_pro_keys.py
+++ b/src/translate_rapid_pro_keys.py
@@ -132,6 +132,15 @@ class TranslateRapidProKeys(object):
                 new_key = remapping.pipeline_key
                 
                 if old_key in td and new_key not in td:
+                    # Some "old keys" translate to the same new key. This is sometimes desirable, for example if we ask
+                    # the same demog question to the same person in multiple places, we should take take their 
+                    # newest response. However, if their newest response is "null" in the flow exported from Rapid Pro,
+                    # taking the newest response would cause loss of some valuable responses. This check ensures we
+                    # are taking the most recent response, unless the most response is "null" and there was a more
+                    # substantive response in the past.
+                    if td[old_key] is None and remapped.get(new_key) is not None:
+                        continue
+
                     remapped[new_key] = td[old_key]
 
             td.append_data(remapped, Metadata(user, Metadata.get_call_location(), TimeUtils.utc_now_as_iso_string()))


### PR DESCRIPTION
See the comment in the code for a full description of what's going on.

This fixes an issue which was causing the outputs generated by master to differ from those generated and shared for analysis. The error was introduced by PR #34. That PR was tested and its outputs compared against the previous commit, but on a random subset of the data for speed. None of the messages in the subset were impacted by this issue, which is how this was missed (indeed < 10 messages turned out to be affected in the whole dataset).