### PR TITLE
Correct the post-folding fix-up code to look for key presence rather than ""

### DIFF
--- a/src/analysis_file.py
+++ b/src/analysis_file.py
@@ -113,7 +113,7 @@ class AnalysisFile(object):
                         continue
 
                     if cc.coding_mode == CodingModes.MULTIPLE:
-                        if td.get(plan.raw_field, "") != "":
+                        if plan.raw_field in td:
                             td.append_data({f"{cc.analysis_file_key}{Codes.TRUE_MISSING}": Codes.MATRIX_0},
                                            Metadata(user, Metadata.get_call_location(), TimeUtils.utc_now_as_iso_string()))
 


### PR DESCRIPTION
The rest of the pipeline was updated to use key presence rather than "" when we converted from using Rapid Pro's Value fields to its Text fields, so we should have done the same here.

This issue is only known to impact people who answer both weeks, and where they only sent noise in one week, which was 2 of about 5000 on OCHA.