### PR TITLE
Produce demographic_distributions.csv

### DIFF
--- a/generate_analysis_graphs.py
+++ b/generate_analysis_graphs.py
@@ -212,13 +212,15 @@ if __name__ == "__main__":
         writer = csv.DictWriter(f, fieldnames=headers, lineterminator="\n")
         writer.writeheader()
 
+        last_demographic = None
         for demographic, counts in demographic_distributions.items():
             for code_string_value, number_of_individuals in counts.items():
                 writer.writerow({
-                    "Variable": demographic,
+                    "Variable": demographic if demographic != last_demographic else "",
                     "Code": code_string_value,
                     "Number of Individuals": number_of_individuals
                 })
+                last_demographic = demographic
 
     log.info("Graphing the per-episode engagement counts...")
     # Graph the number of messages in each episode

--- a/generate_analysis_graphs.py
+++ b/generate_analysis_graphs.py
@@ -198,14 +198,16 @@ if __name__ == "__main__":
                 demographic_distributions[cc.analysis_file_key][code.string_value] = 0
 
     for ind in individuals:
-        if ind["consent_withdrawn"] == Codes.FALSE:
-            for plan in PipelineConfiguration.DEMOG_CODING_PLANS:
-                for cc in plan.coding_configurations:
-                    if cc.analysis_file_key is None:
-                        continue
+        if ind["consent_withdrawn"] == Codes.TRUE:
+            continue
 
-                    code = cc.code_scheme.get_code_with_code_id(ind[cc.coded_field]["CodeID"])
-                    demographic_distributions[cc.analysis_file_key][code.string_value] += 1
+        for plan in PipelineConfiguration.DEMOG_CODING_PLANS:
+            for cc in plan.coding_configurations:
+                if cc.analysis_file_key is None:
+                    continue
+
+                code = cc.code_scheme.get_code_with_code_id(ind[cc.coded_field]["CodeID"])
+                demographic_distributions[cc.analysis_file_key][code.string_value] += 1
 
     with open(f"{output_dir}/demographic_distributions.csv", "w") as f:
         headers = ["Variable", "Code", "Number of Individuals"]

--- a/generate_analysis_graphs.py
+++ b/generate_analysis_graphs.py
@@ -210,7 +210,7 @@ if __name__ == "__main__":
                 demographic_distributions[cc.analysis_file_key][code.string_value] += 1
 
     with open(f"{output_dir}/demographic_distributions.csv", "w") as f:
-        headers = ["Variable", "Code", "Number of Individuals"]
+        headers = ["Demographic", "Code", "Number of Individuals"]
         writer = csv.DictWriter(f, fieldnames=headers, lineterminator="\n")
         writer.writeheader()
 
@@ -218,7 +218,7 @@ if __name__ == "__main__":
         for demographic, counts in demographic_distributions.items():
             for code_string_value, number_of_individuals in counts.items():
                 writer.writerow({
-                    "Variable": demographic if demographic != last_demographic else "",
+                    "Demographic": demographic if demographic != last_demographic else "",
                     "Code": code_string_value,
                     "Number of Individuals": number_of_individuals
                 })

--- a/generate_analysis_graphs.py
+++ b/generate_analysis_graphs.py
@@ -184,6 +184,9 @@ if __name__ == "__main__":
             writer.writerow(row)
 
     log.info("Computing the demographic distributions...")
+    # Compute the number of individuals with each demographic code.
+    # Count excludes individuals who withdrew consent.  STOP codes in each scheme are not exported, as it would look
+    # like 0 individuals opted out otherwise, which could be confusing.
     # TODO: Report percentages?
     # TODO: Handle distributions for other variables too or just demographics?
     # TODO: Categorise age
@@ -195,6 +198,8 @@ if __name__ == "__main__":
 
             demographic_distributions[cc.analysis_file_key] = OrderedDict()
             for code in cc.code_scheme.codes:
+                if code.control_code == Codes.STOP:
+                    continue
                 demographic_distributions[cc.analysis_file_key][code.string_value] = 0
 
     for ind in individuals:
@@ -207,6 +212,8 @@ if __name__ == "__main__":
                     continue
 
                 code = cc.code_scheme.get_code_with_code_id(ind[cc.coded_field]["CodeID"])
+                if code.control_code == Codes.STOP:
+                    continue
                 demographic_distributions[cc.analysis_file_key][code.string_value] += 1
 
     with open(f"{output_dir}/demographic_distributions.csv", "w") as f:

--- a/generate_analysis_graphs.py
+++ b/generate_analysis_graphs.py
@@ -185,7 +185,7 @@ if __name__ == "__main__":
 
     log.info("Computing the demographic distributions...")
     # Compute the number of individuals with each demographic code.
-    # Count excludes individuals who withdrew consent.  STOP codes in each scheme are not exported, as it would look
+    # Count excludes individuals who withdrew consent. STOP codes in each scheme are not exported, as it would look
     # like 0 individuals opted out otherwise, which could be confusing.
     # TODO: Report percentages?
     # TODO: Handle distributions for other variables too or just demographics?

--- a/generate_analysis_graphs.py
+++ b/generate_analysis_graphs.py
@@ -184,6 +184,10 @@ if __name__ == "__main__":
             writer.writerow(row)
 
     log.info("Computing the demographic distributions...")
+    # TODO: Report percentages
+    # TODO: Report just the normal codes?
+    # TODO: Handle distributions for other variables too or just demographics?
+    # TODO: Categorise age?
     demographic_distributions = OrderedDict()  # of analysis_file_key -> code string_value -> number of individuals
     for plan in PipelineConfiguration.DEMOG_CODING_PLANS:
         for cc in plan.coding_configurations:

--- a/generate_analysis_graphs.py
+++ b/generate_analysis_graphs.py
@@ -205,7 +205,7 @@ if __name__ == "__main__":
                     if cc.analysis_file_key is None:
                         continue
 
-                    code = cc.code_scheme.get_code_with_id(ind[cc.coded_field]["CodeID"])
+                    code = cc.code_scheme.get_code_with_code_id(ind[cc.coded_field]["CodeID"])
                     demographic_distributions[cc.analysis_file_key][code.string_value] += 1
 
     with open(f"{output_dir}/demographic_distributions.csv", "w") as f:
@@ -221,8 +221,6 @@ if __name__ == "__main__":
                     "Number of Individuals": number_of_individuals
                 })
 
-    chart = altair.Chart(
-        altair.Data(values=[{"show": k, "count": v} for k, v in individuals_per_show.items()])
     log.info("Graphing the per-episode engagement counts...")
     # Graph the number of messages in each episode
     altair.Chart(

--- a/generate_analysis_graphs.py
+++ b/generate_analysis_graphs.py
@@ -184,9 +184,9 @@ if __name__ == "__main__":
             writer.writerow(row)
 
     log.info("Computing the demographic distributions...")
-    # TODO: Report percentages
+    # TODO: Report percentages?
     # TODO: Handle distributions for other variables too or just demographics?
-    # TODO: Categorise age?
+    # TODO: Categorise age
     demographic_distributions = OrderedDict()  # of analysis_file_key -> code string_value -> number of individuals
     for plan in PipelineConfiguration.DEMOG_CODING_PLANS:
         for cc in plan.coding_configurations:

--- a/generate_analysis_graphs.py
+++ b/generate_analysis_graphs.py
@@ -185,7 +185,6 @@ if __name__ == "__main__":
 
     log.info("Computing the demographic distributions...")
     # TODO: Report percentages
-    # TODO: Report just the normal codes?
     # TODO: Handle distributions for other variables too or just demographics?
     # TODO: Categorise age?
     demographic_distributions = OrderedDict()  # of analysis_file_key -> code string_value -> number of individuals

--- a/src/lib/pipeline_configuration.py
+++ b/src/lib/pipeline_configuration.py
@@ -112,7 +112,7 @@ class PipelineConfiguration(object):
         else:
             return Codes.NOT_CODED
 
-    SURVEY_CODING_PLANS = [
+    OPERATOR_CODING_PLAN = \
         CodingPlan(raw_field="operator_raw",
                    coding_configurations=[
                        CodingConfiguration(
@@ -123,8 +123,9 @@ class PipelineConfiguration(object):
                            folding_mode=FoldingModes.ASSERT_EQUAL
                        )
                    ],
-                   raw_field_folding_mode=FoldingModes.ASSERT_EQUAL),
+                   raw_field_folding_mode=FoldingModes.ASSERT_EQUAL)
 
+    DEMOG_CODING_PLANS = [
         CodingPlan(raw_field="location_raw",
                    time_field="location_time",
                    coda_filename="location.json",
@@ -234,8 +235,10 @@ class PipelineConfiguration(object):
                        )
                    ],
                    ws_code=CodeSchemes.WS_CORRECT_DATASET.get_code_with_match_value("in idp camp"),
-                   raw_field_folding_mode=FoldingModes.ASSERT_EQUAL),
+                   raw_field_folding_mode=FoldingModes.ASSERT_EQUAL)
+    ]
 
+    FOLLOW_UP_CODING_PLANS = [
         CodingPlan(raw_field="have_voice_raw",
                    time_field="have_voice_time",
                    coda_filename="have_voice.json",
@@ -267,6 +270,8 @@ class PipelineConfiguration(object):
                    ws_code=CodeSchemes.WS_CORRECT_DATASET.get_code_with_match_value("suggestions"),
                    raw_field_folding_mode=FoldingModes.ASSERT_EQUAL)
     ]
+
+    SURVEY_CODING_PLANS = [OPERATOR_CODING_PLAN] + DEMOG_CODING_PLANS + FOLLOW_UP_CODING_PLANS
 
     def __init__(self, raw_data_sources, phone_number_uuid_table, timestamp_remappings,
                  rapid_pro_key_remappings, project_start_date, project_end_date, filter_test_messages, move_ws_messages,


### PR DESCRIPTION
Requires data generated by #70 but can be reviewed independently of that PR.

Example output: https://drive.google.com/file/d/1ZmCIy0G_QKHArymO8H37PRIFn8C3LNNv/view?usp=sharing

Outputs generated by previous analysis methods: https://docs.google.com/spreadsheets/d/1uEHLcvg6ZMGZoqzD2pJFj16RrwLCVVjo/edit#gid=447268902

Differences:
- Column headers more verbose and more in line with pipeline terminology. It's really important that these are checked.
- We now show control and meta codes, not just the normal codes, as discussed elsewhere.
- Not yet categorising age.
- Not showing percentages due to lack of input on what those should be a percentage of.
