### PR TITLE
Generate theme_distributions.csv

### DIFF
--- a/generate_analysis_graphs.py
+++ b/generate_analysis_graphs.py
@@ -234,9 +234,9 @@ if __name__ == "__main__":
     # Compute the theme distributions
     log.info("Computing the theme distributions...")
 
-    def make_demog_counts_dict():
-        demog_counts = OrderedDict()
-        demog_counts["Total"] = 0
+    def make_survey_counts_dict():
+        survey_counts = OrderedDict()
+        survey_counts["Total"] = 0
         for plan in PipelineConfiguration.SURVEY_CODING_PLANS:
             for cc in plan.coding_configurations:
                 if cc.analysis_file_key is None:
@@ -244,10 +244,10 @@ if __name__ == "__main__":
                 for code in cc.code_scheme.codes:
                     if code.control_code == Codes.STOP:
                         continue  # Ignore STOP codes because we already excluded everyone who opted out.
-                    demog_counts[f"{cc.analysis_file_key}:{code.string_value}"] = 0
-        return demog_counts
+                    survey_counts[f"{cc.analysis_file_key}:{code.string_value}"] = 0
+        return survey_counts
 
-    def update_demog_counts(counts, td):
+    def update_survey_counts(survey_counts, td):
         for plan in PipelineConfiguration.SURVEY_CODING_PLANS:
             for cc in plan.coding_configurations:
                 if cc.analysis_file_key is None:
@@ -256,29 +256,29 @@ if __name__ == "__main__":
                     code = cc.code_scheme.get_code_with_code_id(td[cc.coded_field]["CodeID"])
                     if code.control_code == Codes.STOP:
                         continue
-                    counts[f"{cc.analysis_file_key}:{code.string_value}"] += 1
+                    survey_counts[f"{cc.analysis_file_key}:{code.string_value}"] += 1
                 else:
                     assert cc.coding_mode == CodingModes.MULTIPLE
                     for label in td[cc.coded_field]:
                         code = cc.code_scheme.get_code_with_code_id(label["CodeID"])
-                        counts[f"{cc.analysis_file_key}:{code.string_value}"] += 1
+                        survey_counts[f"{cc.analysis_file_key}:{code.string_value}"] += 1
 
 
     episodes = OrderedDict()
     for episode_plan in PipelineConfiguration.RQA_CODING_PLANS:
-        # Prepare empty counts of the demogs for each variable
+        # Prepare empty counts of the survey responses for each variable
         themes = OrderedDict()
         episodes[episode_plan.raw_field] = themes
         for cc in episode_plan.coding_configurations:
             if cc.coding_mode == CodingModes.SINGLE:
-                themes[cc.analysis_file_key] = make_demog_counts_dict()
+                themes[cc.analysis_file_key] = make_survey_counts_dict()
             else:
                 assert cc.coding_mode == CodingModes.MULTIPLE
-                themes["Total"] = make_demog_counts_dict()
+                themes["Total"] = make_survey_counts_dict()
                 for code in cc.code_scheme.codes:
                     if code.control_code == Codes.STOP:
                         continue
-                    themes[f"{cc.analysis_file_key}{code.string_value}"] = make_demog_counts_dict()
+                    themes[f"{cc.analysis_file_key}{code.string_value}"] = make_survey_counts_dict()
 
         # Fill in the counts by iterating over every individual
         for td in individuals:
@@ -288,31 +288,31 @@ if __name__ == "__main__":
             for cc in episode_plan.coding_configurations:
                 if cc.coding_mode == CodingModes.SINGLE:
                     themes[cc.analysis_file_key]["Total"] += 1
-                    update_demog_counts(themes[cc.analysis_file_key], td)
+                    update_survey_counts(themes[cc.analysis_file_key], td)
                 else:
                     assert cc.coding_mode == CodingModes.MULTIPLE
                     themes["Total"]["Total"] += 1
-                    update_demog_counts(themes["Total"], td)
+                    update_survey_counts(themes["Total"], td)
                     for label in td[cc.coded_field]:
                         code = cc.code_scheme.get_code_with_code_id(label["CodeID"])
                         if code.control_code == Codes.STOP:
                             continue
                         themes[f"{cc.analysis_file_key}{code.string_value}"]["Total"] += 1
-                        update_demog_counts(themes[f"{cc.analysis_file_key}{code.string_value}"], td)
+                        update_survey_counts(themes[f"{cc.analysis_file_key}{code.string_value}"], td)
 
     with open(f"{output_dir}/theme_distributions.csv", "w") as f:
-        headers = ["Question", "Variable"] + list(make_demog_counts_dict().keys())
+        headers = ["Question", "Variable"] + list(make_survey_counts_dict().keys())
         writer = csv.DictWriter(f, fieldnames=headers, lineterminator="\n")
         writer.writeheader()
 
         last_row_episode = None
         for episode, themes in episodes.items():
-            for theme, demog_counts in themes.items():
+            for theme, survey_counts in themes.items():
                 row = {
                     "Question": episode if episode != last_row_episode else "",
                     "Variable": theme,
                 }
-                row.update(demog_counts)
+                row.update(survey_counts)
                 writer.writerow(row)
                 last_row_episode = episode
 

--- a/generate_analysis_graphs.py
+++ b/generate_analysis_graphs.py
@@ -315,7 +315,7 @@ if __name__ == "__main__":
                 row.update(survey_counts)
                 writer.writerow(row)
                 last_row_episode = episode
-    exit(0)
+
     log.info("Graphing the per-episode engagement counts...")
     # Graph the number of messages in each episode
     altair.Chart(

--- a/generate_analysis_graphs.py
+++ b/generate_analysis_graphs.py
@@ -301,8 +301,8 @@ if __name__ == "__main__":
                         update_survey_counts(themes[f"{cc.analysis_file_key}{code.string_value}"], td)
 
     with open(f"{output_dir}/theme_distributions.csv", "w") as f:
-        f.write("CAUTION: The totals reported here show the number of times each theme was reported not "
-                "the number of individuals. Demographic totals apply to all codes (including NA NC etc.) \n")
+        f.write("CAUTION: The totals reported here show the number of times each theme was reported not the "
+                "number of individuals or messages. Demographic totals apply to all codes (including NA NC etc.) \n")
 
         headers = ["Question", "Variable"] + list(make_survey_counts_dict().keys())
         writer = csv.DictWriter(f, fieldnames=headers, lineterminator="\n")

--- a/generate_analysis_graphs.py
+++ b/generate_analysis_graphs.py
@@ -217,6 +217,7 @@ if __name__ == "__main__":
                 themes[cc.analysis_file_key] = make_demog_counts_dict()
             else:
                 assert cc.coding_mode == CodingModes.MULTIPLE
+                themes["Total"] = make_demog_counts_dict()
                 for code in cc.code_scheme.codes:
                     themes[f"{cc.analysis_file_key}{code.string_value}"] = make_demog_counts_dict()
 
@@ -231,6 +232,8 @@ if __name__ == "__main__":
                     update_demog_counts(themes[cc.analysis_file_key], td)
                 else:
                     assert cc.coding_mode == CodingModes.MULTIPLE
+                    themes["Total"]["Total"] += 1
+                    update_demog_counts(themes["Total"], td)
                     for label in td[cc.coded_field]:
                         code = cc.code_scheme.get_code_with_code_id(label["CodeID"])
                         themes[f"{cc.analysis_file_key}{code.string_value}"]["Total"] += 1

--- a/generate_analysis_graphs.py
+++ b/generate_analysis_graphs.py
@@ -194,7 +194,7 @@ if __name__ == "__main__":
                 if cc.analysis_file_key is None:
                     continue
                 for code in cc.code_scheme.codes:
-                    demog_counts[code.string_value] = 0
+                    demog_counts[f"{cc.analysis_file_key}:{code.string_value}"] = 0
         return demog_counts
 
     def update_demog_counts(counts, td):
@@ -204,7 +204,7 @@ if __name__ == "__main__":
                     continue
                 if cc.coding_mode == CodingModes.SINGLE:
                     code = cc.code_scheme.get_code_with_code_id(td[cc.coded_field]["CodeID"])
-                    counts[code.string_value] += 1
+                    counts[f"{cc.analysis_file_key}:{code.string_value}"] += 1
 
 
     episodes = OrderedDict()

--- a/generate_analysis_graphs.py
+++ b/generate_analysis_graphs.py
@@ -241,14 +241,16 @@ if __name__ == "__main__":
         writer = csv.DictWriter(f, fieldnames=headers, lineterminator="\n")
         writer.writeheader()
 
+        last_row_episode = None
         for episode, themes in episodes.items():
             for theme, demog_counts in themes.items():
                 row = {
-                    "Question": episode,
+                    "Question": episode if episode != last_row_episode else "",
                     "Variable": theme,
                 }
                 row.update(demog_counts)
                 writer.writerow(row)
+                last_row_episode = episode
                 
     exit(0)
 

--- a/generate_analysis_graphs.py
+++ b/generate_analysis_graphs.py
@@ -194,6 +194,8 @@ if __name__ == "__main__":
                 if cc.analysis_file_key is None:
                     continue
                 for code in cc.code_scheme.codes:
+                    if code.control_code == Codes.STOP:
+                        continue  # Ignore STOP codes because we already excluded everyone who opted out.
                     demog_counts[f"{cc.analysis_file_key}:{code.string_value}"] = 0
         return demog_counts
 
@@ -204,7 +206,11 @@ if __name__ == "__main__":
                     continue
                 if cc.coding_mode == CodingModes.SINGLE:
                     code = cc.code_scheme.get_code_with_code_id(td[cc.coded_field]["CodeID"])
+                    if code.control_code == Codes.STOP:
+                        continue
                     counts[f"{cc.analysis_file_key}:{code.string_value}"] += 1
+                else:
+                    pass  # TODO: Implement
 
 
     episodes = OrderedDict()
@@ -219,6 +225,8 @@ if __name__ == "__main__":
                 assert cc.coding_mode == CodingModes.MULTIPLE
                 themes["Total"] = make_demog_counts_dict()
                 for code in cc.code_scheme.codes:
+                    if code.control_code == Codes.STOP:
+                        continue
                     themes[f"{cc.analysis_file_key}{code.string_value}"] = make_demog_counts_dict()
 
         # Fill in the counts by iterating over every individual
@@ -236,6 +244,8 @@ if __name__ == "__main__":
                     update_demog_counts(themes["Total"], td)
                     for label in td[cc.coded_field]:
                         code = cc.code_scheme.get_code_with_code_id(label["CodeID"])
+                        if code.control_code == Codes.STOP:
+                            continue
                         themes[f"{cc.analysis_file_key}{code.string_value}"]["Total"] += 1
                         update_demog_counts(themes[f"{cc.analysis_file_key}{code.string_value}"], td)
 

--- a/generate_analysis_graphs.py
+++ b/generate_analysis_graphs.py
@@ -301,6 +301,9 @@ if __name__ == "__main__":
                         update_survey_counts(themes[f"{cc.analysis_file_key}{code.string_value}"], td)
 
     with open(f"{output_dir}/theme_distributions.csv", "w") as f:
+        f.write("CAUTION: The totals reported here show the number of times each theme was reported not "
+                "the number of individuals. Demographic totals apply to all codes (including NA NC etc.) \n")
+
         headers = ["Question", "Variable"] + list(make_survey_counts_dict().keys())
         writer = csv.DictWriter(f, fieldnames=headers, lineterminator="\n")
         writer.writeheader()

--- a/generate_analysis_graphs.py
+++ b/generate_analysis_graphs.py
@@ -210,7 +210,10 @@ if __name__ == "__main__":
                         continue
                     counts[f"{cc.analysis_file_key}:{code.string_value}"] += 1
                 else:
-                    pass  # TODO: Implement
+                    assert cc.coding_mode == CodingModes.MULTIPLE
+                    for label in td[cc.coded_field]:
+                        code = cc.code_scheme.get_code_with_code_id(label["CodeID"])
+                        counts[f"{cc.analysis_file_key}:{code.string_value}"] += 1
 
 
     episodes = OrderedDict()

--- a/generate_analysis_graphs.py
+++ b/generate_analysis_graphs.py
@@ -319,8 +319,6 @@ if __name__ == "__main__":
                 writer.writerow(row)
                 last_row_episode = episode
 
-    exit(0)
-
     log.info("Graphing the per-episode engagement counts...")
     # Graph the number of messages in each episode
     altair.Chart(


### PR DESCRIPTION
There are ongoing discussions around what the totals should count. For now, they count everything, but with a cautionary note given at the top of the file as to how to interpret them. Opening a PR now so we can deploy this on WorldBank-PLR, with that known caveat.

Sample output: https://drive.google.com/file/d/1EgaYEfkePF2cK7T9dOB7Ap-klWb5OzWL/view?usp=sharing

Equivalent output generated by previous methods: https://docs.google.com/spreadsheets/d/1uEHLcvg6ZMGZoqzD2pJFj16RrwLCVVjo/edit#gid=2100534684

Compared to the previous method:
 - Deliberately doesn't export percentages, because these make the CSV harder for machines to read.
- Shows all surveys, not just the demographics.
- Shows all codes (except STOP because these were excluded), not just the normal codes.
- Doesn't yet categorise age.

Please also check the terminology, particularly in the CSV headings.