### PR TITLE
Fold only coded fields, then convert to string values

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -4,7 +4,7 @@ verify_ssl = true
 name = "pypi"
 
 [packages]
-CoreDataModules = {editable = true,git = "https://www.github.com/AfricasVoices/CoreDataModules",ref = "fold-list-of-labels"}
+CoreDataModules = {editable = true,git = "https://www.github.com/AfricasVoices/CoreDataModules",ref = "master"}
 PipelineInfrastructure = {editable = true,git = "https://www.github.com/AfricasVoices/Pipeline-Infrastructure",ref = "v0.0.3"}
 RapidProTools = {editable = true,git = "https://www.github.com/AfricasVoices/RapidProTools",ref = "v0.3.0"}
 pytz = "*"

--- a/Pipfile
+++ b/Pipfile
@@ -4,7 +4,7 @@ verify_ssl = true
 name = "pypi"
 
 [packages]
-CoreDataModules = {editable = true,git = "https://www.github.com/AfricasVoices/CoreDataModules",ref = "new-fold-interface"}
+CoreDataModules = {editable = true,git = "https://www.github.com/AfricasVoices/CoreDataModules",ref = "fold-yes-no-amb-label"}
 PipelineInfrastructure = {editable = true,git = "https://www.github.com/AfricasVoices/Pipeline-Infrastructure",ref = "v0.0.3"}
 RapidProTools = {editable = true,git = "https://www.github.com/AfricasVoices/RapidProTools",ref = "v0.3.0"}
 pytz = "*"

--- a/Pipfile
+++ b/Pipfile
@@ -4,7 +4,7 @@ verify_ssl = true
 name = "pypi"
 
 [packages]
-CoreDataModules = {editable = true,git = "https://www.github.com/AfricasVoices/CoreDataModules",ref = "fold-all"}
+CoreDataModules = {editable = true,git = "https://www.github.com/AfricasVoices/CoreDataModules",ref = "fold-list-of-labels"}
 PipelineInfrastructure = {editable = true,git = "https://www.github.com/AfricasVoices/Pipeline-Infrastructure",ref = "v0.0.3"}
 RapidProTools = {editable = true,git = "https://www.github.com/AfricasVoices/RapidProTools",ref = "v0.3.0"}
 pytz = "*"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "e6b84591c33335cab90c584110478876d30d8c256a92368bdb3e600d5faee4ab"
+            "sha256": "253ab8934f487290fabb44d0717dd94e118f9111e19e1ffb0dfee7dcc5a53914"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -61,7 +61,7 @@
         "coredatamodules": {
             "editable": true,
             "git": "https://www.github.com/AfricasVoices/CoreDataModules",
-            "ref": "6f6fead9aa081ade486644bd2314d98b4808f8ee"
+            "ref": "08c3d8bd0763689f320b99001a58dcb1d9f1f2a5"
         },
         "deprecation": {
             "hashes": [
@@ -79,20 +79,20 @@
         },
         "firebase-admin": {
             "hashes": [
-                "sha256:c0af81d62f1d36cc352e69eac8eacef700f31f322074ca86447a5a16240b628c"
+                "sha256:2e9341e2f01d31f8cde0c39a58e34ff0804dc4fa1d3cfe5a5c4043da13098fe0"
             ],
-            "version": "==3.2.0"
+            "version": "==3.2.1"
         },
         "google-api-core": {
             "extras": [
                 "grpc"
             ],
             "hashes": [
-                "sha256:b95895a9398026bc0500cf9b4a3f82c3f72c3f9150b26ff53af40c74e91c264a",
-                "sha256:df8adc4b97f5ab4328a0e745bee77877cf4a7d4601cb1cd5959d2bbf8fba57aa"
+                "sha256:2d661c8d650a1df5805d0e360121cb55c55d8bd29f858fa62cbe943e59ce89f7",
+                "sha256:9006e1641599345056cc690a934e1262107c78d969d72cf96412f6db5d32147f"
             ],
             "markers": "platform_python_implementation != 'PyPy'",
-            "version": "==1.14.3"
+            "version": "==1.15.0"
         },
         "google-api-python-client": {
             "hashes": [
@@ -103,10 +103,10 @@
         },
         "google-auth": {
             "hashes": [
-                "sha256:17c5b7bf7b9f4c188beba5590d170c1546f31f99c1919621422a6a0011323d97",
-                "sha256:44fd26d86e9a04fbb21064a0295288044cb2b920d305501b5f8d546452f246bd"
+                "sha256:038a921618620491502eeb4ed5b7af6a8ee2a7950918a5b3e0d718e841aff4da",
+                "sha256:a977375be9f9c46cd20ffb90f0532a27fa0e171eb47373de270b6028005b8e8b"
             ],
-            "version": "==1.8.1"
+            "version": "==1.9.0"
         },
         "google-auth-httplib2": {
             "hashes": [

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "473608e035f30c9b45aa7185cd2178b7c65a2317dc7a1075b86a08d5253c04af"
+            "sha256": "e6b84591c33335cab90c584110478876d30d8c256a92368bdb3e600d5faee4ab"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -18,11 +18,11 @@
     "default": {
         "altair": {
             "hashes": [
-                "sha256:540c3651a4df7310efd0c4f3f5060ebfee50c2b9546ca865068f992357b1a562",
-                "sha256:9f7c521239ac5a207c3cffc29c5bdde0854fff0dec0b5f91f086ba8e5f1de8a9"
+                "sha256:92dcd7b84c715f8e02bbdf37e36193a4af8138b5b064c05f237e6ed41573880a",
+                "sha256:9947ae1e5f99b55c3ffaaf376494cd504bcdbfd33b8326061500c86ec0d89d93"
             ],
             "index": "pypi",
-            "version": "==3.3.0"
+            "version": "==4.0.0"
         },
         "attrs": {
             "hashes": [
@@ -61,7 +61,7 @@
         "coredatamodules": {
             "editable": true,
             "git": "https://www.github.com/AfricasVoices/CoreDataModules",
-            "ref": "7d44caa3dc8cbc5d71fbc6c30ade602ca9a47f83"
+            "ref": "6f6fead9aa081ade486644bd2314d98b4808f8ee"
         },
         "deprecation": {
             "hashes": [
@@ -103,10 +103,10 @@
         },
         "google-auth": {
             "hashes": [
-                "sha256:84105be98837fb8436e9d0bcb7a279fd85fa1d97bb35a077e70ba2fb95bcc983",
-                "sha256:baf1b3f8b29a5f96f66753ad848473699322b63f4d68964e510554b12d002443"
+                "sha256:17c5b7bf7b9f4c188beba5590d170c1546f31f99c1919621422a6a0011323d97",
+                "sha256:44fd26d86e9a04fbb21064a0295288044cb2b920d305501b5f8d546452f246bd"
             ],
-            "version": "==1.7.1"
+            "version": "==1.8.1"
         },
         "google-auth-httplib2": {
             "hashes": [
@@ -117,10 +117,10 @@
         },
         "google-cloud-core": {
             "hashes": [
-                "sha256:0ee17abc74ff02176bee221d4896a00a3c202f3fb07125a7d814ccabd20d7eb5",
-                "sha256:10750207c1a9ad6f6e082d91dbff3920443bdaf1c344a782730489a9efa802f1"
+                "sha256:49036087c1170c3fad026e45189f17092b8c584a9accb2d73d1854f494e223ae",
+                "sha256:63c93d989d92a782efe8d9606ea2ad37673361ab0c3e7f965a5640d30ff14f20"
             ],
-            "version": "==1.0.3"
+            "version": "==1.1.0"
         },
         "google-cloud-firestore": {
             "hashes": [
@@ -220,11 +220,11 @@
         },
         "importlib-metadata": {
             "hashes": [
-                "sha256:b044f07694ef14a6683b097ba56bd081dbc7cdc7c7fe46011e499dfecc082f21",
-                "sha256:e6ac600a142cf2db707b1998382cc7fc3b02befb7273876e01b8ad10b9652742"
+                "sha256:073a852570f92da5f744a3472af1b61e28e9f78ccf0c9117658dc32b15de7b45",
+                "sha256:d95141fbfa7ef2ec65cfd945e2af7e5a6ddbd7c8d9a25e66ff3be8e3daf9f60f"
             ],
             "markers": "python_version < '3.8'",
-            "version": "==1.1.0"
+            "version": "==1.3.0"
         },
         "iso8601": {
             "hashes": [
@@ -283,10 +283,10 @@
         },
         "more-itertools": {
             "hashes": [
-                "sha256:53ff73f186307d9c8ef17a9600309154a6ae27f25579e80af4db8f047ba14bc2",
-                "sha256:a0ea684c39bc4315ba7aae406596ef191fd84f873d2d2751f84d64e81a7a2d45"
+                "sha256:b84b238cce0d9adad5ed87e745778d20a3f8487d0f0cb8b8a586816c7496458d",
+                "sha256:c833ef592a0324bcc6a60e48440da07645063c453880c9477ceb22490aec1564"
             ],
-            "version": "==8.0.0"
+            "version": "==8.0.2"
         },
         "msgpack": {
             "hashes": [
@@ -385,24 +385,24 @@
         },
         "protobuf": {
             "hashes": [
-                "sha256:0ba5d7626dbc4ce78971c3e62ec37f84c8139ea7008c008660d3312cf11e0db8",
-                "sha256:189b706f72e8b7ddc965168a79ff296ca5b7bdd95b5b05208afb9818a681c712",
-                "sha256:340965444aafc7aac7e3586e930f5b3f8347ca9b350afab60bac84dcc0b94437",
-                "sha256:44fbc7b1786ab975ec9eba9da765398d58ec705d1c8e856b0523b8f9c1c53cf7",
-                "sha256:48d96b559fab3063feaebd316352e3418424629d59b77dbcb96ecc4c594d7f5f",
-                "sha256:5e32923c7896c49b1d3a327fe25a76363d200acdfa97844f5647f1bf9f298da8",
-                "sha256:6662442fbf22796dbd942bb15b664d70dcc25ae28d371b7e4ca6261e9bc495b7",
-                "sha256:6bb5d999faceee281bc4a2fc77866c61af7be4b7e5efadc930c42f234a99cafd",
-                "sha256:83b38b7b61b7c60af0fa03a71c27c4232117453a62ccf69a511284793a400751",
-                "sha256:90c22f4fd4e01279efc4e4911dafe308f35fcc4310bcb89bcee4d3ca20210d20",
-                "sha256:97b08853b9bb71512ed52381f05cf2d4179f4234825b505d8f8d2bb9d9429939",
-                "sha256:aef47082114428b47db73876ecb7751802548830ce5c95dba7ebe24d5e196d7c",
-                "sha256:b89ed3ba88ea5ec8b2c704a5ae747c9038ee1faff277fcddac75f850e645f7e1",
-                "sha256:be5afc2e1f5c320bd4a38e73d8b02c67d72dbee370a004732c923c7c8a472f72",
-                "sha256:d1c18853c7ad3c8e34edfafc6488fc24f4221c15b516c14796032cc53f8cde94",
-                "sha256:f4370d0e3d6e1ac2f80911651691ac540901f661b372036ea72637546ba98202"
+                "sha256:0265379852b9e1f76af6d3d3fe4b3c383a595cc937594bda8565cf69a96baabd",
+                "sha256:29bd1ed46b2536ad8959401a2f02d2d7b5a309f8e97518e4f92ca6c5ba74dbed",
+                "sha256:3175d45698edb9a07c1a78a1a4850e674ce8988f20596580158b1d0921d0f057",
+                "sha256:34a7270940f86da7a28be466ac541c89b6dbf144a6348b9cf7ac6f56b71006ce",
+                "sha256:38cbc830a4a5ba9956763b0f37090bfd14dd74e72762be6225de2ceac55f4d03",
+                "sha256:665194f5ad386511ac8d8a0bd57b9ab37b8dd2cd71969458777318e774b9cd46",
+                "sha256:839bad7d115c77cdff29b488fae6a3ab503ce9a4192bd4c42302a6ea8e5d0f33",
+                "sha256:934a9869a7f3b0d84eca460e386fba1f7ba2a0c1a120a2648bc41fadf50efd1c",
+                "sha256:aecdf12ef6dc7fd91713a6da93a86c2f2a8fe54840a3b1670853a2b7402e77c9",
+                "sha256:c4e90bc27c0691c76e09b5dc506133451e52caee1472b8b3c741b7c912ce43ef",
+                "sha256:c65d135ea2d85d40309e268106dab02d3bea723db2db21c23ecad4163ced210b",
+                "sha256:c98dea04a1ff41a70aff2489610f280004831798cb36a068013eed04c698903d",
+                "sha256:d9049aa194378a426f0b2c784e2054565bf6f754d20fcafdee7102a6250556e8",
+                "sha256:e028fee51c96de4e81924484c77111dfdea14010ecfc906ea5b252209b0c4de6",
+                "sha256:e84ad26fb50091b1ea676403c0dd2bd47663099454aa6d88000b1dafecab0941",
+                "sha256:e88a924b591b06d0191620e9c8aa75297b3111066bb09d49a24bae1054a10c13"
             ],
-            "version": "==3.11.0"
+            "version": "==3.11.1"
         },
         "pyasn1": {
             "hashes": [

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "8fd5175331aada2d4fa812dc09ebbeac0a43601fc57d355a89cb10e6f3d8392e"
+            "sha256": "9fc8dc4f56b5472e126a5b2ed4c95e5812324b1a7eb29eac40d981c6dcecfd25"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -61,7 +61,7 @@
         "coredatamodules": {
             "editable": true,
             "git": "https://www.github.com/AfricasVoices/CoreDataModules",
-            "ref": "610cccca0e3e0fdfc66cfa08ad82d98f89421263"
+            "ref": "6ee2b8b8ee1e1f860522053dc21ece81ef4b6a90"
         },
         "deprecation": {
             "hashes": [
@@ -385,24 +385,24 @@
         },
         "protobuf": {
             "hashes": [
-                "sha256:125713564d8cfed7610e52444c9769b8dcb0b55e25cc7841f2290ee7bc86636f",
-                "sha256:1accdb7a47e51503be64d9a57543964ba674edac103215576399d2d0e34eac77",
-                "sha256:27003d12d4f68e3cbea9eb67427cab3bfddd47ff90670cb367fcd7a3a89b9657",
-                "sha256:3264f3c431a631b0b31e9db2ae8c927b79fc1a7b1b06b31e8e5bcf2af91fe896",
-                "sha256:3c5ab0f5c71ca5af27143e60613729e3488bb45f6d3f143dc918a20af8bab0bf",
-                "sha256:45dcf8758873e3f69feab075e5f3177270739f146255225474ee0b90429adef6",
-                "sha256:56a77d61a91186cc5676d8e11b36a5feb513873e4ae88d2ee5cf530d52bbcd3b",
-                "sha256:5984e4947bbcef5bd849d6244aec507d31786f2dd3344139adc1489fb403b300",
-                "sha256:6b0441da73796dd00821763bb4119674eaf252776beb50ae3883bed179a60b2a",
-                "sha256:6f6677c5ade94d4fe75a912926d6796d5c71a2a90c2aeefe0d6f211d75c74789",
-                "sha256:84a825a9418d7196e2acc48f8746cf1ee75877ed2f30433ab92a133f3eaf8fbe",
-                "sha256:b842c34fe043ccf78b4a6cf1019d7b80113707d68c88842d061fa2b8fb6ddedc",
-                "sha256:ca33d2f09dae149a1dcf942d2d825ebb06343b77b437198c9e2ef115cf5d5bc1",
-                "sha256:db83b5c12c0cd30150bb568e6feb2435c49ce4e68fe2d7b903113f0e221e58fe",
-                "sha256:f50f3b1c5c1c1334ca7ce9cad5992f098f460ffd6388a3cabad10b66c2006b09",
-                "sha256:f99f127909731cafb841c52f9216e447d3e4afb99b17bebfad327a75aee206de"
+                "sha256:0ba5d7626dbc4ce78971c3e62ec37f84c8139ea7008c008660d3312cf11e0db8",
+                "sha256:189b706f72e8b7ddc965168a79ff296ca5b7bdd95b5b05208afb9818a681c712",
+                "sha256:340965444aafc7aac7e3586e930f5b3f8347ca9b350afab60bac84dcc0b94437",
+                "sha256:44fbc7b1786ab975ec9eba9da765398d58ec705d1c8e856b0523b8f9c1c53cf7",
+                "sha256:48d96b559fab3063feaebd316352e3418424629d59b77dbcb96ecc4c594d7f5f",
+                "sha256:5e32923c7896c49b1d3a327fe25a76363d200acdfa97844f5647f1bf9f298da8",
+                "sha256:6662442fbf22796dbd942bb15b664d70dcc25ae28d371b7e4ca6261e9bc495b7",
+                "sha256:6bb5d999faceee281bc4a2fc77866c61af7be4b7e5efadc930c42f234a99cafd",
+                "sha256:83b38b7b61b7c60af0fa03a71c27c4232117453a62ccf69a511284793a400751",
+                "sha256:90c22f4fd4e01279efc4e4911dafe308f35fcc4310bcb89bcee4d3ca20210d20",
+                "sha256:97b08853b9bb71512ed52381f05cf2d4179f4234825b505d8f8d2bb9d9429939",
+                "sha256:aef47082114428b47db73876ecb7751802548830ce5c95dba7ebe24d5e196d7c",
+                "sha256:b89ed3ba88ea5ec8b2c704a5ae747c9038ee1faff277fcddac75f850e645f7e1",
+                "sha256:be5afc2e1f5c320bd4a38e73d8b02c67d72dbee370a004732c923c7c8a472f72",
+                "sha256:d1c18853c7ad3c8e34edfafc6488fc24f4221c15b516c14796032cc53f8cde94",
+                "sha256:f4370d0e3d6e1ac2f80911651691ac540901f661b372036ea72637546ba98202"
             ],
-            "version": "==3.10.0"
+            "version": "==3.11.0"
         },
         "pyasn1": {
             "hashes": [
@@ -427,9 +427,9 @@
         },
         "pyrsistent": {
             "hashes": [
-                "sha256:eb6545dbeb1aa69ab1fb4809bfbf5a8705e44d92ef8fc7c2361682a47c46c778"
+                "sha256:f3b280d030afb652f79d67c5586157c5c1355c9a58dfc7940566e28d28f3df1b"
             ],
-            "version": "==0.15.5"
+            "version": "==0.15.6"
         },
         "python-dateutil": {
             "hashes": [

--- a/src/analysis_file.py
+++ b/src/analysis_file.py
@@ -14,7 +14,42 @@ from src.lib.pipeline_configuration import CodingModes, FoldingModes
 
 class AnalysisFile(object):
     @staticmethod
-    def generate(user, data, csv_by_message_output_path, csv_by_individual_output_path):
+    def export_to_csv(user, data, csv_path, export_keys, consent_withdrawn_key):
+        # Convert codes to their string/matrix values
+        for td in data:
+            analysis_dict = dict()
+            for plan in PipelineConfiguration.RQA_CODING_PLANS + PipelineConfiguration.SURVEY_CODING_PLANS:
+                for cc in plan.coding_configurations:
+                    if cc.analysis_file_key is None:
+                        continue
+
+                    if cc.coding_mode == CodingModes.SINGLE:
+                        analysis_dict[cc.analysis_file_key] = \
+                            cc.code_scheme.get_code_with_code_id(td[cc.coded_field]["CodeID"]).string_value
+                    else:
+                        assert cc.coding_mode == CodingModes.MULTIPLE
+                        show_matrix_keys = []
+                        for code in cc.code_scheme.codes:
+                            show_matrix_keys.append(f"{cc.analysis_file_key}{code.string_value}")
+
+                        for label in td[cc.coded_field]:
+                            code_string_value = cc.code_scheme.get_code_with_code_id(label["CodeID"]).string_value
+                            analysis_dict[f"{cc.analysis_file_key}{code_string_value}"] = Codes.MATRIX_1
+
+                        for key in show_matrix_keys:
+                            if key not in analysis_dict:
+                                analysis_dict[key] = Codes.MATRIX_0
+            td.append_data(analysis_dict,
+                           Metadata(user, Metadata.get_call_location(), TimeUtils.utc_now_as_iso_string()))
+
+        # Hide data from participants who opted out
+        ConsentUtils.set_stopped(user, data, consent_withdrawn_key, additional_keys=export_keys)
+
+        with open(csv_path, "w") as f:
+            TracedDataCSVIO.export_traced_data_iterable_to_csv(data, f, headers=export_keys)
+    
+    @classmethod
+    def generate(cls, user, data, csv_by_message_output_path, csv_by_individual_output_path):
         # Serializer is currently overflowing
         # TODO: Investigate/address the cause of this.
         # sys.setrecursionlimit(15000)
@@ -41,19 +76,17 @@ class AnalysisFile(object):
 
                     if cc.folding_mode == FoldingModes.ASSERT_EQUAL:
                         fold_strategies[cc.coded_field] = FoldStrategies.assert_label_ids_equal
-                        fold_strategies[cc.analysis_file_key] = FoldStrategies.assert_equal
                     elif cc.folding_mode == FoldingModes.YES_NO_AMB:
-                        fold_strategies[cc.coded_field] = FoldStrategies.yes_no_amb_label
-                        fold_strategies[cc.analysis_file_key] = FoldStrategies.yes_no_amb
+                        assert False, "Yes/no/ambivalent labels not supported yet"
+                        # fold_strategies[cc.coded_field] = FoldStrategies.yes_no_amb_label
                     else:
                         assert False, f"Incompatible folding_mode {plan.folding_mode}"
                 else:
                     assert cc.folding_mode == FoldingModes.MATRIX
                     for code in cc.code_scheme.codes:
                         export_keys.append(f"{cc.analysis_file_key}{code.string_value}")
-                        fold_strategies[f"{cc.analysis_file_key}{code.string_value}"] = FoldStrategies.matrix
-                        fold_strategies[cc.coded_field] = \
-                            lambda x, y, code_scheme=cc.code_scheme: FoldStrategies.list_of_labels(code_scheme, x, y)
+                    fold_strategies[cc.coded_field] = \
+                        lambda x, y, code_scheme=cc.code_scheme: FoldStrategies.list_of_labels(code_scheme, x, y)
 
             export_keys.append(plan.raw_field)
             if plan.raw_field_folding_mode == FoldingModes.CONCATENATE:
@@ -62,33 +95,6 @@ class AnalysisFile(object):
                 fold_strategies[plan.raw_field] = FoldStrategies.assert_equal
             else:
                 assert False, f"Incompatible raw_field_folding_mode {plan.raw_field_folding_mode}"
-
-        # Convert codes to their string/matrix values
-        for td in data:
-            analysis_dict = dict()
-            for plan in PipelineConfiguration.RQA_CODING_PLANS + PipelineConfiguration.SURVEY_CODING_PLANS:
-                for cc in plan.coding_configurations:
-                    if cc.analysis_file_key is None:
-                        continue
-
-                    if cc.coding_mode == CodingModes.SINGLE:
-                        analysis_dict[cc.analysis_file_key] = \
-                            cc.code_scheme.get_code_with_code_id(td[cc.coded_field]["CodeID"]).string_value
-                    else:
-                        assert cc.coding_mode == CodingModes.MULTIPLE
-                        show_matrix_keys = []
-                        for code in cc.code_scheme.codes:
-                            show_matrix_keys.append(f"{cc.analysis_file_key}{code.string_value}")
-
-                        for label in td.get(cc.coded_field, []):
-                            code_string_value = cc.code_scheme.get_code_with_code_id(label['CodeID']).string_value
-                            analysis_dict[f"{cc.analysis_file_key}{code_string_value}"] = Codes.MATRIX_1
-
-                        for key in show_matrix_keys:
-                            if key not in analysis_dict:
-                                analysis_dict[key] = Codes.MATRIX_0
-            td.append_data(analysis_dict,
-                           Metadata(user, Metadata.get_call_location(), TimeUtils.utc_now_as_iso_string()))
 
         # Set consent withdrawn based on presence of data coded as "stop"
         ConsentUtils.determine_consent_withdrawn(
@@ -102,79 +108,10 @@ class AnalysisFile(object):
             to_be_folded.append(td.copy())
 
         folded_data = FoldTracedData.fold_iterable_of_traced_data(
-            user, data, lambda td: td["uid"], fold_strategies
+            user, to_be_folded, lambda td: td["uid"], fold_strategies
         )
 
-        # Fix-up _NA and _NC keys, which are currently being set incorrectly by
-        # FoldTracedData.fold_iterable_of_traced_data when there are multiple radio shows
-        # TODO: Update FoldTracedData to handle NA and NC correctly under multiple radio shows
-        #       This is probably best done by updating Core to support folding lists of labels, then updating this
-        #       file to convert from labels to matrix representation and other string values after folding.
-        for td in folded_data:
-            for plan in PipelineConfiguration.RQA_CODING_PLANS + PipelineConfiguration.SURVEY_CODING_PLANS:
-                for cc in plan.coding_configurations:
-                    if cc.analysis_file_key is None:
-                        continue
-
-                    if cc.coding_mode == CodingModes.MULTIPLE:
-                        if plan.raw_field in td:
-                            td.append_data({f"{cc.analysis_file_key}{Codes.TRUE_MISSING}": Codes.MATRIX_0},
-                                           Metadata(user, Metadata.get_call_location(), TimeUtils.utc_now_as_iso_string()))
-
-                        contains_non_nc_key = False
-                        for code in cc.code_scheme.codes:
-                            if td.get(f"{cc.analysis_file_key}{code.string_value}") == Codes.MATRIX_1 and \
-                                    code.control_code != Codes.NOT_CODED:
-                                contains_non_nc_key = True
-                        if contains_non_nc_key:
-                            td.append_data({f"{cc.analysis_file_key}{Codes.NOT_CODED}": Codes.MATRIX_0},
-                                           Metadata(user, Metadata.get_call_location(), TimeUtils.utc_now_as_iso_string()))
-                        else:
-                            td.append_data({f"{cc.analysis_file_key}{Codes.NOT_CODED}": Codes.MATRIX_1},
-                                           Metadata(user, Metadata.get_call_location(), TimeUtils.utc_now_as_iso_string()))
-
-        # Check that the new and old strategies of folding give the same response
-        # TODO: Remove this when the old strategies are removed, as this will serve no purpose then.
-        for td in folded_data:
-            for plan in PipelineConfiguration.RQA_CODING_PLANS + PipelineConfiguration.SURVEY_CODING_PLANS:
-                for cc in plan.coding_configurations:
-                    if cc.analysis_file_key is None:
-                        continue
-
-                    if cc.coding_mode == CodingModes.SINGLE:
-                        if cc.folding_mode == FoldingModes.ASSERT_EQUAL:
-                            assert cc.code_scheme.get_code_with_code_id(td[cc.coded_field]["CodeID"]).string_value == \
-                                td[cc.analysis_file_key]
-                        else:
-                            assert cc.folding_mode == FoldingModes.YES_NO_AMB
-                            assert cc.code_scheme.get_code_with_code_id(td[cc.coded_field]["CodeID"]).string_value == \
-                                   td[cc.analysis_file_key], \
-                                f"{td['uid']}: " \
-                                f"{cc.code_scheme.get_code_with_code_id(td[cc.coded_field]['CodeID']).string_value}, " \
-                                f"{td[cc.analysis_file_key]}"
-                    else:
-                        assert cc.coding_mode == CodingModes.MULTIPLE
-                        old_matrix_values = dict()
-                        for code in cc.code_scheme.codes:
-                            old_matrix_values[code.code_id] = td[f"{cc.analysis_file_key}{code.string_value}"]
-
-                        new_matrix_values = dict()
-                        for code in cc.code_scheme.codes:
-                            new_matrix_values[code.code_id] = Codes.MATRIX_0
-                        for label in td[cc.coded_field]:
-                            new_matrix_values[label["CodeID"]] = Codes.MATRIX_1
-
-                        assert new_matrix_values == old_matrix_values, f"{td['uid']}\n{old_matrix_values}\n{new_matrix_values}"
-
-        # Process consent
-        ConsentUtils.set_stopped(user, data, consent_withdrawn_key, additional_keys=export_keys)
-        ConsentUtils.set_stopped(user, folded_data, consent_withdrawn_key, additional_keys=export_keys)
-
-        # Output to CSV with one message per row
-        with open(csv_by_message_output_path, "w") as f:
-            TracedDataCSVIO.export_traced_data_iterable_to_csv(data, f, headers=export_keys)
-
-        with open(csv_by_individual_output_path, "w") as f:
-            TracedDataCSVIO.export_traced_data_iterable_to_csv(folded_data, f, headers=export_keys)
+        cls.export_to_csv(user, data, csv_by_message_output_path, export_keys, consent_withdrawn_key)
+        cls.export_to_csv(user, folded_data, csv_by_individual_output_path, export_keys, consent_withdrawn_key)
 
         return data, folded_data

--- a/src/lib/consent_utils.py
+++ b/src/lib/consent_utils.py
@@ -25,8 +25,9 @@ class ConsentUtils(object):
                     if cc.code_scheme.get_code_with_code_id(td[cc.coded_field]["CodeID"]).control_code == Codes.STOP:
                         return True
                 else:
-                    if td[f"{cc.analysis_file_key}{Codes.STOP}"] == Codes.MATRIX_1:
-                        return True
+                    for label in td[cc.coded_field]:
+                        if cc.code_scheme.get_code_with_code_id(label["CodeID"]).control_code == Codes.STOP:
+                            return True
         return False
 
     @classmethod


### PR DESCRIPTION
Review #73 first, which requires https://github.com/AfricasVoices/CoreDataModules/pull/164.

The current analysis stage runs the following steps:
 - detect consent
 - convert the coded fields to their string representations
 - fold both the labels and their strings, separately using different folding algorithms
 - fix the results of the matrix folding algorithm, because it's impossible to fold a pair of matrix keys correctly without having the context of what the other matrix values for that question are.
- check that the label folding and string folding (w/ cleanup) gives the same results.
- overwrite non-consenting individuals with "STOP"
- export the analysis CSVs

This PR refactors this to run these steps to instead:
- detect consent
- fold the labels
- for each of the individuals/messages datasets:
    - convert the coded fields to their string representations
    - overwrite non-consenting individuals with "STOP"
    - export the analysis CSVs

I think this is much cleaner. There's no need for fix-up, no need to maintain as many fold strategies, and no need to do the work of folding twice for each field. 