### PR TITLE
Categorise age

### DIFF
--- a/code_schemes/age_category.json
+++ b/code_schemes/age_category.json
@@ -1,0 +1,179 @@
+{
+  "SchemeID": "Scheme-eea1ce89",
+  "Name": "Age Category",
+  "Version": "0.0.0.1",
+  "Codes": [
+    {
+      "CodeID": "code-6790828e",
+      "CodeType": "Normal",
+      "DisplayText": "0 to 13",
+      "NumericValue": 1,
+      "StringValue": "0_to_13",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "0 to 13"
+      ]
+    },
+    {
+      "CodeID": "code-dc66377c",
+      "CodeType": "Normal",
+      "DisplayText": "14 to 17",
+      "NumericValue": 1,
+      "StringValue": "14_to_17",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "14 to 17"
+      ]
+    },
+    {
+      "CodeID": "code-1b52fcfe",
+      "CodeType": "Normal",
+      "DisplayText": "18 to 34",
+      "NumericValue": 1,
+      "StringValue": "18_to_34",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "18 to 34"
+      ]
+    },
+    {
+      "CodeID": "code-73425f56",
+      "CodeType": "Normal",
+      "DisplayText": "35 to 53",
+      "NumericValue": 1,
+      "StringValue": "35_to_53",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "35 to 53"
+      ]
+    },
+    {
+      "CodeID": "code-bdb788fc",
+      "CodeType": "Normal",
+      "DisplayText": "54 to 99",
+      "NumericValue": 1,
+      "StringValue": "54_to_99",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "54 to 99"
+      ]
+    },
+    {
+      "CodeID": "code-NA-f93d3eb7",
+      "CodeType": "Control",
+      "ControlCode": "NA",
+      "DisplayText": "NA (missing)",
+      "NumericValue": -10,
+      "StringValue": "NA",
+      "VisibleInCoda": false
+    },
+    {
+      "CodeID": "code-NS-2c11b7c9",
+      "CodeType": "Control",
+      "ControlCode": "NS",
+      "DisplayText": "NS (skip)",
+      "NumericValue": -20,
+      "StringValue": "NS",
+      "VisibleInCoda": false
+    },
+    {
+      "CodeID": "code-NC-42f1d983",
+      "CodeType": "Control",
+      "ControlCode": "NC",
+      "DisplayText": "NC (not coded)",
+      "NumericValue": -30,
+      "StringValue": "NC",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-NR-5e3eee23",
+      "CodeType": "Control",
+      "ControlCode": "NR",
+      "DisplayText": "NR (not reviewed)",
+      "NumericValue": -40,
+      "StringValue": "NR",
+      "VisibleInCoda": false
+    },
+    {
+      "CodeID": "code-NIC-99631cb8",
+      "CodeType": "Control",
+      "ControlCode": "NIC",
+      "DisplayText": "NIC (not internally consistent)",
+      "NumericValue": -50,
+      "StringValue": "NIC",
+      "VisibleInCoda": false
+    },
+    {
+      "CodeID": "code-STOP-08b832a8",
+      "CodeType": "Control",
+      "ControlCode": "STOP",
+      "DisplayText": "STOP",
+      "NumericValue": -90,
+      "StringValue": "STOP",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-WS-adb25603b7af",
+      "CodeType": "Control",
+      "ControlCode": "WS",
+      "DisplayText": "WS (wrong scheme)",
+      "NumericValue": -100,
+      "StringValue": "WS",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-CE-016c1e22",
+      "CodeType": "Control",
+      "ControlCode": "CE",
+      "DisplayText": "CE (coding error)",
+      "NumericValue": -110,
+      "StringValue": "CE",
+      "VisibleInCoda": false
+    },
+    {
+      "CodeID": "code-PB-a434a800",
+      "CodeType": "Meta",
+      "MetaCode": "push_back",
+      "DisplayText": "push back",
+      "NumericValue": -100000,
+      "StringValue": "push_back",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-SQ-5e8f0122",
+      "CodeType": "Meta",
+      "MetaCode": "showtime_question",
+      "DisplayText": "showtime question",
+      "NumericValue": -100030,
+      "StringValue": "showtime_question",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-Q-a5d3700d",
+      "CodeType": "Meta",
+      "MetaCode": "question",
+      "DisplayText": "question",
+      "NumericValue": -100010,
+      "StringValue": "question",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-G-97cb3199",
+      "CodeType": "Meta",
+      "MetaCode": "greeting",
+      "DisplayText": "greeting",
+      "NumericValue": -100020,
+      "StringValue": "greeting",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-OI-c5f1d054",
+      "CodeType": "Meta",
+      "MetaCode": "opt-in",
+      "DisplayText": "opt-in",
+      "NumericValue": -100040,
+      "StringValue": "opt_in",
+      "VisibleInCoda": true
+    }
+  ]
+}

--- a/code_schemes/age_category.json
+++ b/code_schemes/age_category.json
@@ -6,56 +6,56 @@
     {
       "CodeID": "code-6790828e",
       "CodeType": "Normal",
-      "DisplayText": "0 to 13",
+      "DisplayText": "10 to 14",
       "NumericValue": 1,
-      "StringValue": "0_to_13",
+      "StringValue": "10_to_14",
       "VisibleInCoda": true,
       "MatchValues": [
-        "0 to 13"
+        "10 to 14"
       ]
     },
     {
       "CodeID": "code-dc66377c",
       "CodeType": "Normal",
-      "DisplayText": "14 to 17",
+      "DisplayText": "15 to 18",
       "NumericValue": 1,
-      "StringValue": "14_to_17",
+      "StringValue": "15_to_18",
       "VisibleInCoda": true,
       "MatchValues": [
-        "14 to 17"
+        "15 to 18"
       ]
     },
     {
       "CodeID": "code-1b52fcfe",
       "CodeType": "Normal",
-      "DisplayText": "18 to 34",
+      "DisplayText": "19 to 35",
       "NumericValue": 1,
-      "StringValue": "18_to_34",
+      "StringValue": "19_to_35",
       "VisibleInCoda": true,
       "MatchValues": [
-        "18 to 34"
+        "19 to 35"
       ]
     },
     {
       "CodeID": "code-73425f56",
       "CodeType": "Normal",
-      "DisplayText": "35 to 53",
+      "DisplayText": "36 to 54",
       "NumericValue": 1,
-      "StringValue": "35_to_53",
+      "StringValue": "36_to_54",
       "VisibleInCoda": true,
       "MatchValues": [
-        "35 to 53"
+        "36 to 54"
       ]
     },
     {
       "CodeID": "code-bdb788fc",
       "CodeType": "Normal",
-      "DisplayText": "54 to 99",
+      "DisplayText": "55 to 99",
       "NumericValue": 1,
-      "StringValue": "54_to_99",
+      "StringValue": "55_to_99",
       "VisibleInCoda": true,
       "MatchValues": [
-        "54 to 99"
+        "55 to 99"
       ]
     },
     {

--- a/src/lib/code_imputation_functions.py
+++ b/src/lib/code_imputation_functions.py
@@ -103,6 +103,10 @@ def impute_somalia_location_codes(user, data, location_configurations):
 
 
 def impute_age_category(user, data, age_configurations):
+    # TODO: By accepting a list of age_configurations but then requiring that list to contain code schemes in a
+    #       certain order, it looks like we're providing more flexibility than we actually do. We should change this
+    #       to explicitly accept age and age_category configurations, which requires refactoring all of the
+    #       code imputation functions.
     age_cc = age_configurations[0]
     age_category_cc = age_configurations[1]
     
@@ -119,6 +123,7 @@ def impute_age_category(user, data, age_configurations):
         age_code = age_cc.code_scheme.get_code_with_code_id(age_label["CodeID"])
 
         if age_code.code_type == CodeTypes.NORMAL:
+            # TODO: If these age categories are standard across projects, move this to Core as a new cleaner.
             age_category = None
             for age_range, category in age_categories.items():
                 if age_range[0] <= age_code.numeric_value <= age_range[1]:

--- a/src/lib/code_imputation_functions.py
+++ b/src/lib/code_imputation_functions.py
@@ -111,11 +111,11 @@ def impute_age_category(user, data, age_configurations):
     age_category_cc = age_configurations[1]
     
     age_categories = {
-        (0, 13): "0 to 13",
-        (14, 17): "14 to 17",
-        (18, 34): "18 to 34",
-        (35, 53): "35 to 53",
-        (54, 99): "54 to 99"
+        (10, 14): "10 to 14",
+        (15, 18): "15 to 18",
+        (19, 35): "19 to 35",
+        (36, 54): "36 to 54",
+        (55, 99): "55 to 99"
     }
 
     for td in data:

--- a/src/lib/code_schemes.py
+++ b/src/lib/code_schemes.py
@@ -22,6 +22,7 @@ class CodeSchemes(object):
     SOMALIA_ZONE = _open_scheme("somalia_zone.json")
     GENDER = _open_scheme("gender.json")
     AGE = _open_scheme("age.json")
+    AGE_CATEGORY = _open_scheme("age_category.json")
     RECENTLY_DISPLACED = _open_scheme("recently_displaced.json")
     IN_IDP_CAMP = _open_scheme("in_idp_camp.json")
 

--- a/src/lib/pipeline_configuration.py
+++ b/src/lib/pipeline_configuration.py
@@ -198,10 +198,17 @@ class PipelineConfiguration(object):
                            code_scheme=CodeSchemes.AGE,
                            cleaner=lambda text: PipelineConfiguration.clean_age_with_range_filter(text),
                            coded_field="age_coded",
-                           analysis_file_key="age",
+                           folding_mode=FoldingModes.ASSERT_EQUAL
+                       ),
+                       CodingConfiguration(
+                           coding_mode=CodingModes.SINGLE,
+                           code_scheme=CodeSchemes.AGE_CATEGORY,
+                           coded_field="age_category_coded",
+                           analysis_file_key="age_category",
                            folding_mode=FoldingModes.ASSERT_EQUAL
                        )
                    ],
+                   code_imputation_function=code_imputation_functions.impute_age_category,
                    ws_code=CodeSchemes.WS_CORRECT_DATASET.get_code_with_match_value("age"),
                    raw_field_folding_mode=FoldingModes.ASSERT_EQUAL),
 


### PR DESCRIPTION
Categorises coded age values after importing the labelled data into the pipeline from Coda. This updates the analysis files and automated analysis stages to output and operate over categorised ages without any modification to those stages.

The age category code scheme used is that used in OCHA's analysis, so we can test that these updates give the same result. We'll probably use a different, RDA code scheme on future projects.