### PR TITLE
Move all the consent detection code to the same place

### DIFF
--- a/src/analysis_file.py
+++ b/src/analysis_file.py
@@ -1,4 +1,3 @@
-import time
 from collections import OrderedDict
 
 from core_data_modules.cleaners import Codes
@@ -56,9 +55,6 @@ class AnalysisFile(object):
 
         # Set consent withdrawn based on presence of data coded as "stop"
         consent_withdrawn_key = "consent_withdrawn"
-        for td in data:
-            td.append_data({consent_withdrawn_key: Codes.FALSE},
-                           Metadata(user, Metadata.get_call_location(), time.time()))
         ConsentUtils.determine_consent_withdrawn(
             user, data, PipelineConfiguration.RQA_CODING_PLANS + PipelineConfiguration.SURVEY_CODING_PLANS,
             consent_withdrawn_key

--- a/src/analysis_file.py
+++ b/src/analysis_file.py
@@ -54,10 +54,15 @@ class AnalysisFile(object):
         # TODO: Investigate/address the cause of this.
         # sys.setrecursionlimit(15000)
 
+        # Set consent withdrawn based on presence of data coded as "stop"
         consent_withdrawn_key = "consent_withdrawn"
         for td in data:
             td.append_data({consent_withdrawn_key: Codes.FALSE},
                            Metadata(user, Metadata.get_call_location(), time.time()))
+        ConsentUtils.determine_consent_withdrawn(
+            user, data, PipelineConfiguration.RQA_CODING_PLANS + PipelineConfiguration.SURVEY_CODING_PLANS,
+            consent_withdrawn_key
+        )
 
         # Set the list of keys to be exported and how they are to be handled when folding
         fold_strategies = OrderedDict()
@@ -65,7 +70,7 @@ class AnalysisFile(object):
         fold_strategies[consent_withdrawn_key] = FoldStrategies.boolean_or
 
         export_keys = ["uid", consent_withdrawn_key]
-
+        
         for plan in PipelineConfiguration.RQA_CODING_PLANS + PipelineConfiguration.SURVEY_CODING_PLANS:
             for cc in plan.coding_configurations:
                 if cc.analysis_file_key is None:
@@ -77,7 +82,7 @@ class AnalysisFile(object):
                     if cc.folding_mode == FoldingModes.ASSERT_EQUAL:
                         fold_strategies[cc.coded_field] = FoldStrategies.assert_label_ids_equal
                     elif cc.folding_mode == FoldingModes.YES_NO_AMB:
-                        assert False, "Yes/no/ambivalent labels not supported yet"
+                        assert False, "Folding yes/no/ambivalent labels is not yet supported"
                         # fold_strategies[cc.coded_field] = FoldStrategies.yes_no_amb_label
                     else:
                         assert False, f"Incompatible folding_mode {plan.folding_mode}"
@@ -95,12 +100,6 @@ class AnalysisFile(object):
                 fold_strategies[plan.raw_field] = FoldStrategies.assert_equal
             else:
                 assert False, f"Incompatible raw_field_folding_mode {plan.raw_field_folding_mode}"
-
-        # Set consent withdrawn based on presence of data coded as "stop"
-        ConsentUtils.determine_consent_withdrawn(
-            user, data, PipelineConfiguration.RQA_CODING_PLANS + PipelineConfiguration.SURVEY_CODING_PLANS,
-            consent_withdrawn_key
-        )
 
         # Fold data to have one respondent per row
         to_be_folded = []

--- a/src/lib/consent_utils.py
+++ b/src/lib/consent_utils.py
@@ -33,10 +33,10 @@ class ConsentUtils(object):
     @classmethod
     def determine_consent_withdrawn(cls, user, data, coding_plans, withdrawn_key="consent_withdrawn"):
         """
-        Determines whether consent has been withdrawn, by searching for Codes.STOP in the given list of keys.
+        Determines whether consent has been withdrawn, by searching for Codes.STOP in the given list of coding plans.
 
         TracedData objects where a stop code is found will have the key-value pair <withdrawn_key>: Codes.TRUE
-        appended. Objects where a stop code is not found are not modified.
+        appended, or Codes.FALSE if no stop code is found.
 
         Note that this does not actually set any other keys to Codes.STOP. Use Consent.set_stopped for this purpose.
 
@@ -44,11 +44,14 @@ class ConsentUtils(object):
         :type user: str
         :param data: TracedData objects to determine consent for.
         :type data: iterable of TracedData
-        :param coding_plans:
+        :param coding_plans: Coding plans for the fields to search for stop codes.
         :type coding_plans: iterable of CodingPlan
         :param withdrawn_key: Name of key to use for the consent withdrawn field.
         :type withdrawn_key: str
         """
+        for td in data:
+            td.append_data({withdrawn_key: Codes.FALSE}, Metadata(user, Metadata.get_call_location(), time.time()))
+
         stopped_uids = set()
         for td in data:
             if cls.td_has_stop_code(td, coding_plans):


### PR DESCRIPTION
Moves the two parts of consent detection into the same function, run at the start of the analysis_file method