### PR TITLE
Friendly dataset names

### DIFF
--- a/generate_analysis_graphs.py
+++ b/generate_analysis_graphs.py
@@ -76,8 +76,8 @@ if __name__ == "__main__":
     log.info("Computing the per-episode and per-season engagement counts...")
     engagement_counts = OrderedDict()
     for plan in PipelineConfiguration.RQA_CODING_PLANS:
-        engagement_counts[plan.analysis_name] = {
-            "Episode": plan.analysis_name,
+        engagement_counts[plan.dataset_name] = {
+            "Episode": plan.dataset_name,
             "Total Messages": 0,
             "Relevant Messages": 0,
             "Total Participants": 0,
@@ -100,7 +100,7 @@ if __name__ == "__main__":
         if msg["consent_withdrawn"] == Codes.FALSE:
             for plan in PipelineConfiguration.RQA_CODING_PLANS:
                 if plan.raw_field in msg:
-                    engagement_counts[plan.analysis_name]["Total Messages"] += 1
+                    engagement_counts[plan.dataset_name]["Total Messages"] += 1
                     engagement_counts["Total"]["Total Messages"] += 1
 
                     # Get all the codes for this message under this code scheme
@@ -116,7 +116,7 @@ if __name__ == "__main__":
                     # Increment the count of relevant messages if the code is labelled with at least one normal code.
                     code_types = [code.code_type for code in codes]
                     if CodeTypes.NORMAL in code_types:
-                        engagement_counts[plan.analysis_name]["Relevant Messages"] += 1
+                        engagement_counts[plan.dataset_name]["Relevant Messages"] += 1
                         engagement_counts["Total"]["Relevant Messages"] += 1
 
     # Compute, per episode and across the season:
@@ -127,7 +127,7 @@ if __name__ == "__main__":
             engagement_counts["Total"]["Total Participants"] += 1
             for plan in PipelineConfiguration.RQA_CODING_PLANS:
                 if plan.raw_field in ind:
-                    engagement_counts[plan.analysis_name]["Total Participants"] += 1
+                    engagement_counts[plan.dataset_name]["Total Participants"] += 1
 
     # Compute:
     #  - % Relevant Messages, by computing Relevant Messages / Total Messages * 100, to 1 decimal place.

--- a/generate_analysis_graphs.py
+++ b/generate_analysis_graphs.py
@@ -76,9 +76,8 @@ if __name__ == "__main__":
     log.info("Computing the per-episode and per-season engagement counts...")
     engagement_counts = OrderedDict()
     for plan in PipelineConfiguration.RQA_CODING_PLANS:
-        # TODO: Add another field to CodingPlan so that we can give the weeks better names than the raw_field
-        engagement_counts[plan.raw_field] = {
-            "Episode": plan.raw_field,
+        engagement_counts[plan.analysis_name] = {
+            "Episode": plan.analysis_name,
             "Total Messages": 0,
             "Relevant Messages": 0,
             "Total Participants": 0,
@@ -101,7 +100,7 @@ if __name__ == "__main__":
         if msg["consent_withdrawn"] == Codes.FALSE:
             for plan in PipelineConfiguration.RQA_CODING_PLANS:
                 if plan.raw_field in msg:
-                    engagement_counts[plan.raw_field]["Total Messages"] += 1
+                    engagement_counts[plan.analysis_name]["Total Messages"] += 1
                     engagement_counts["Total"]["Total Messages"] += 1
 
                     # Get all the codes for this message under this code scheme
@@ -117,7 +116,7 @@ if __name__ == "__main__":
                     # Increment the count of relevant messages if the code is labelled with at least one normal code.
                     code_types = [code.code_type for code in codes]
                     if CodeTypes.NORMAL in code_types:
-                        engagement_counts[plan.raw_field]["Relevant Messages"] += 1
+                        engagement_counts[plan.analysis_name]["Relevant Messages"] += 1
                         engagement_counts["Total"]["Relevant Messages"] += 1
 
     # Compute, per episode and across the season:
@@ -128,7 +127,7 @@ if __name__ == "__main__":
             engagement_counts["Total"]["Total Participants"] += 1
             for plan in PipelineConfiguration.RQA_CODING_PLANS:
                 if plan.raw_field in ind:
-                    engagement_counts[plan.raw_field]["Total Participants"] += 1
+                    engagement_counts[plan.analysis_name]["Total Participants"] += 1
 
     # Compute:
     #  - % Relevant Messages, by computing Relevant Messages / Total Messages * 100, to 1 decimal place.

--- a/src/lib/pipeline_configuration.py
+++ b/src/lib/pipeline_configuration.py
@@ -39,7 +39,7 @@ class CodingConfiguration(object):
 class CodingPlan(object):
     def __init__(self, raw_field, coding_configurations, raw_field_folding_mode, coda_filename=None, ws_code=None,
                  time_field=None, run_id_field=None, icr_filename=None, id_field=None, code_imputation_function=None,
-                 analysis_name=None):
+                 dataset_name=None):
         self.raw_field = raw_field
         self.time_field = time_field
         self.run_id_field = run_id_field
@@ -49,7 +49,7 @@ class CodingPlan(object):
         self.code_imputation_function = code_imputation_function
         self.ws_code = ws_code
         self.raw_field_folding_mode = raw_field_folding_mode
-        self.analysis_name = analysis_name
+        self.dataset_name = dataset_name
 
         if id_field is None:
             id_field = "{}_id".format(self.raw_field)
@@ -58,7 +58,8 @@ class CodingPlan(object):
 
 class PipelineConfiguration(object):
     RQA_CODING_PLANS = [
-        CodingPlan(raw_field="rqa_s04e01_raw",
+        CodingPlan(dataset_name="Episode 1",
+                   raw_field="rqa_s04e01_raw",
                    time_field="sent_on",
                    run_id_field="rqa_s04e01_run_id",
                    coda_filename="s04e01.json",
@@ -73,10 +74,10 @@ class PipelineConfiguration(object):
                        )
                    ],
                    ws_code=CodeSchemes.WS_CORRECT_DATASET.get_code_with_match_value("s04e01"),
-                   raw_field_folding_mode=FoldingModes.CONCATENATE,
-                   analysis_name="Episode 1"),
+                   raw_field_folding_mode=FoldingModes.CONCATENATE),
 
-        CodingPlan(raw_field="rqa_s04e02_raw",
+        CodingPlan(dataset_name="Episode 2",
+                   raw_field="rqa_s04e02_raw",
                    time_field="sent_on",
                    run_id_field="rqa_s04e02_run_id",
                    coda_filename="s04e02.json",
@@ -91,8 +92,7 @@ class PipelineConfiguration(object):
                        )
                    ],
                    ws_code=CodeSchemes.WS_CORRECT_DATASET.get_code_with_match_value("s04e02"),
-                   raw_field_folding_mode=FoldingModes.CONCATENATE,
-                   analysis_name="Episode 2"),
+                   raw_field_folding_mode=FoldingModes.CONCATENATE),
     ]
 
     @staticmethod

--- a/src/lib/pipeline_configuration.py
+++ b/src/lib/pipeline_configuration.py
@@ -38,7 +38,8 @@ class CodingConfiguration(object):
 # TODO: Rename CodingPlan to something like DatasetConfiguration?
 class CodingPlan(object):
     def __init__(self, raw_field, coding_configurations, raw_field_folding_mode, coda_filename=None, ws_code=None,
-                 time_field=None, run_id_field=None, icr_filename=None, id_field=None, code_imputation_function=None):
+                 time_field=None, run_id_field=None, icr_filename=None, id_field=None, code_imputation_function=None,
+                 analysis_name=None):
         self.raw_field = raw_field
         self.time_field = time_field
         self.run_id_field = run_id_field
@@ -48,6 +49,7 @@ class CodingPlan(object):
         self.code_imputation_function = code_imputation_function
         self.ws_code = ws_code
         self.raw_field_folding_mode = raw_field_folding_mode
+        self.analysis_name = analysis_name
 
         if id_field is None:
             id_field = "{}_id".format(self.raw_field)
@@ -71,7 +73,8 @@ class PipelineConfiguration(object):
                        )
                    ],
                    ws_code=CodeSchemes.WS_CORRECT_DATASET.get_code_with_match_value("s04e01"),
-                   raw_field_folding_mode=FoldingModes.CONCATENATE),
+                   raw_field_folding_mode=FoldingModes.CONCATENATE,
+                   analysis_name="Episode 1"),
 
         CodingPlan(raw_field="rqa_s04e02_raw",
                    time_field="sent_on",
@@ -88,7 +91,8 @@ class PipelineConfiguration(object):
                        )
                    ],
                    ws_code=CodeSchemes.WS_CORRECT_DATASET.get_code_with_match_value("s04e02"),
-                   raw_field_folding_mode=FoldingModes.CONCATENATE),
+                   raw_field_folding_mode=FoldingModes.CONCATENATE,
+                   analysis_name="Episode 2"),
     ]
 
     @staticmethod


### PR DESCRIPTION
Add friendly dataset names to the coding plans, so that analysis CSVs can now read "Episode 1" instead of "rqa_s04e01_raw", for example.

Note this has only been set on the coding plans for the RQAs, as there's nowhere in analysis that needs a friendly dataset name for the demogs yet. At the moment, these are all analysed by code scheme rather than by dataset.