### PR TITLE
Count total relevant participants instead of total relevant themes

### DIFF
--- a/generate_analysis_graphs.py
+++ b/generate_analysis_graphs.py
@@ -265,7 +265,7 @@ if __name__ == "__main__":
                     if code.control_code == Codes.STOP:
                         continue
                     survey_counts[f"{cc.analysis_file_key}:{code.string_value}"] += 1
-                
+
 
     episodes = OrderedDict()
     for episode_plan in PipelineConfiguration.RQA_CODING_PLANS:
@@ -275,7 +275,7 @@ if __name__ == "__main__":
         for cc in episode_plan.coding_configurations:
             # TODO: Add support for CodingModes.SINGLE if we need it e.g. for IMAQAL?
             assert cc.coding_mode == CodingModes.MULTIPLE, "RQAs with single coding modes not supported"
-            themes["Total"] = make_survey_counts_dict()
+            themes["Total Normal Themes"] = make_survey_counts_dict()
             for code in cc.code_scheme.codes:
                 if code.control_code == Codes.STOP:
                     continue
@@ -287,15 +287,16 @@ if __name__ == "__main__":
                 continue
 
             for cc in episode_plan.coding_configurations:
-                assert cc.coding_mode == CodingModes.MULTIPLE
-                themes["Total"]["Total"] += 1
-                update_survey_counts(themes["Total"], td)
+                assert cc.coding_mode == CodingModes.MULTIPLE, "Other CodingModes not (yet) supported"
                 for label in td[cc.coded_field]:
                     code = cc.code_scheme.get_code_with_code_id(label["CodeID"])
                     if code.control_code == Codes.STOP:
                         continue
                     themes[f"{cc.analysis_file_key}{code.string_value}"]["Total"] += 1
                     update_survey_counts(themes[f"{cc.analysis_file_key}{code.string_value}"], td)
+                    if code.code_type == CodeTypes.NORMAL:
+                        themes["Total Normal Themes"]["Total"] += 1
+                        update_survey_counts(themes["Total Normal Themes"], td)
 
     with open(f"{output_dir}/theme_distributions.csv", "w") as f:
         f.write("CAUTION: The totals reported here show the number of times each theme was reported not the "

--- a/generate_analysis_graphs.py
+++ b/generate_analysis_graphs.py
@@ -299,9 +299,6 @@ if __name__ == "__main__":
                 update_survey_counts(themes["Total Relevant Participants"], td)
 
     with open(f"{output_dir}/theme_distributions.csv", "w") as f:
-        f.write("CAUTION: The totals reported here show the number of times each theme was reported not the "
-                "number of individuals or messages. Demographic totals apply to all codes (including NA NC etc.) \n")
-
         headers = ["Question", "Variable"] + list(make_survey_counts_dict().keys())
         writer = csv.DictWriter(f, fieldnames=headers, lineterminator="\n")
         writer.writeheader()

--- a/generate_analysis_graphs.py
+++ b/generate_analysis_graphs.py
@@ -232,7 +232,7 @@ if __name__ == "__main__":
 
     def make_survey_counts_dict():
         survey_counts = OrderedDict()
-        survey_counts["Total"] = 0
+        survey_counts["Total Participants"] = 0
         for plan in PipelineConfiguration.SURVEY_CODING_PLANS:
             for cc in plan.coding_configurations:
                 if cc.analysis_file_key is None:
@@ -289,13 +289,13 @@ if __name__ == "__main__":
                     code = cc.code_scheme.get_code_with_code_id(label["CodeID"])
                     if code.control_code == Codes.STOP:
                         continue
-                    themes[f"{cc.analysis_file_key}{code.string_value}"]["Total"] += 1
+                    themes[f"{cc.analysis_file_key}{code.string_value}"]["Total Participants"] += 1
                     update_survey_counts(themes[f"{cc.analysis_file_key}{code.string_value}"], td)
                     if code.code_type == CodeTypes.NORMAL:
                         relevant_participant = True
 
             if relevant_participant:
-                themes["Total Relevant Participants"]["Total"] += 1
+                themes["Total Relevant Participants"]["Total Participants"] += 1
                 update_survey_counts(themes["Total Relevant Participants"], td)
 
     with open(f"{output_dir}/theme_distributions.csv", "w") as f:

--- a/generate_analysis_graphs.py
+++ b/generate_analysis_graphs.py
@@ -270,8 +270,8 @@ if __name__ == "__main__":
         episodes[episode_plan.raw_field] = themes
         for cc in episode_plan.coding_configurations:
             # TODO: Add support for CodingModes.SINGLE if we need it e.g. for IMAQAL?
-            assert cc.coding_mode == CodingModes.MULTIPLE, "RQAs with single coding modes not supported"
-            themes["Total Normal Themes"] = make_survey_counts_dict()
+            assert cc.coding_mode == CodingModes.MULTIPLE, "Other CodingModes not (yet) supported"
+            themes["Total Relevant Participants"] = make_survey_counts_dict()
             for code in cc.code_scheme.codes:
                 if code.control_code == Codes.STOP:
                     continue
@@ -282,6 +282,7 @@ if __name__ == "__main__":
             if td["consent_withdrawn"] == Codes.TRUE:
                 continue
 
+            relevant_participant = False
             for cc in episode_plan.coding_configurations:
                 assert cc.coding_mode == CodingModes.MULTIPLE, "Other CodingModes not (yet) supported"
                 for label in td[cc.coded_field]:
@@ -291,8 +292,11 @@ if __name__ == "__main__":
                     themes[f"{cc.analysis_file_key}{code.string_value}"]["Total"] += 1
                     update_survey_counts(themes[f"{cc.analysis_file_key}{code.string_value}"], td)
                     if code.code_type == CodeTypes.NORMAL:
-                        themes["Total Normal Themes"]["Total"] += 1
-                        update_survey_counts(themes["Total Normal Themes"], td)
+                        relevant_participant = True
+
+            if relevant_participant:
+                themes["Total Relevant Participants"]["Total"] += 1
+                update_survey_counts(themes["Total Relevant Participants"], td)
 
     with open(f"{output_dir}/theme_distributions.csv", "w") as f:
         f.write("CAUTION: The totals reported here show the number of times each theme was reported not the "


### PR DESCRIPTION
This updates the totals being computed to match those defined here: https://docs.google.com/spreadsheets/d/1u2YnwIXA2OnaUV8Q8ivkCsK6VTJYKApZN4PXBzMnZvw/edit?folder=1QUv8T2KjTRKG9Xf10_GX0paQ29TlssNv#gid=1949452687

Sample output from this PR: https://drive.google.com/file/d/1a23xT4MfrA3Pz522RMB470oDwWydKcIV/view?usp=sharing

And sample output from master, for comparison: https://drive.google.com/file/d/1EgaYEfkePF2cK7T9dOB7Ap-klWb5OzWL/view?usp=sharing

Adding @lukechurch as a reviewer to check the output.