### PR TITLE
Add AnalysisUtils

### DIFF
--- a/generate_analysis_graphs.py
+++ b/generate_analysis_graphs.py
@@ -1,10 +1,10 @@
 import argparse
-from collections import OrderedDict
-
-import altair
 import csv
 import glob
 import json
+from collections import OrderedDict
+
+import altair
 from core_data_modules.cleaners import Codes
 from core_data_modules.logging import Logger
 from core_data_modules.traced_data.io import TracedDataJsonIO
@@ -82,6 +82,7 @@ if __name__ == "__main__":
 
             "Total Messages": "-",  # Can't report this for individual weeks because the data has been overwritten with "STOP"
             "Total Messages with Opt-Ins": len(AnalysisUtils.filter_opt_ins(messages, CONSENT_WITHDRAWN_KEY, [plan])),
+            "Total Labelled Messages": len(AnalysisUtils.filter_labelled(messages, CONSENT_WITHDRAWN_KEY, [plan])),
             "Total Relevant Messages": len(AnalysisUtils.filter_relevant(messages, CONSENT_WITHDRAWN_KEY, [plan])),
 
             "Total Participants": "-",
@@ -93,6 +94,7 @@ if __name__ == "__main__":
 
         "Total Messages": len(messages),
         "Total Messages with Opt-Ins": len(AnalysisUtils.filter_opt_ins(messages, CONSENT_WITHDRAWN_KEY, PipelineConfiguration.RQA_CODING_PLANS)),
+        "Total Labelled Messages": len(AnalysisUtils.filter_labelled(messages, CONSENT_WITHDRAWN_KEY, PipelineConfiguration.RQA_CODING_PLANS)),
         "Total Relevant Messages": len(AnalysisUtils.filter_relevant(messages, CONSENT_WITHDRAWN_KEY, PipelineConfiguration.RQA_CODING_PLANS)),
 
         "Total Participants": len(individuals),
@@ -103,7 +105,7 @@ if __name__ == "__main__":
     with open(f"{output_dir}/engagement_counts.csv", "w") as f:
         headers = [
             "Episode",
-            "Total Messages", "Total Messages with Opt-Ins", "Total Relevant Messages",
+            "Total Messages", "Total Messages with Opt-Ins", "Total Labelled Messages", "Total Relevant Messages",
             "Total Participants", "Total Participants with Opt-Ins", "Total Relevant Participants"
         ]
         writer = csv.DictWriter(f, fieldnames=headers, lineterminator="\n")

--- a/generate_analysis_graphs.py
+++ b/generate_analysis_graphs.py
@@ -1,18 +1,18 @@
 import argparse
-import csv
-import glob
-import json
 from collections import OrderedDict
 
 import altair
+import csv
+import glob
+import json
 from core_data_modules.cleaners import Codes
-from core_data_modules.data_models.code_scheme import CodeTypes
 from core_data_modules.logging import Logger
 from core_data_modules.traced_data.io import TracedDataJsonIO
 from core_data_modules.util import IOUtils
 from storage.google_cloud import google_cloud_utils
 from storage.google_drive import drive_client_wrapper
 
+from src import AnalysisUtils
 from src.lib import PipelineConfiguration
 from src.lib.pipeline_configuration import CodingModes
 
@@ -20,6 +20,7 @@ Logger.set_project_name("OCHA")
 log = Logger(__name__)
 
 IMG_SCALE_FACTOR = 10  # Increase this to increase the resolution of the outputted PNGs
+CONSENT_WITHDRAWN_KEY = "consent_withdrawn"
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="Generates graphs for analysis")
@@ -74,69 +75,37 @@ if __name__ == "__main__":
 
     # Compute the number of messages, individuals, and relevant messages per episode and overall.
     log.info("Computing the per-episode and per-season engagement counts...")
-    engagement_counts = OrderedDict()
+    engagement_counts = OrderedDict()  # of episode name to counts
     for plan in PipelineConfiguration.RQA_CODING_PLANS:
         engagement_counts[plan.dataset_name] = {
             "Episode": plan.dataset_name,
-            "Total Messages": 0,
-            "Relevant Messages": 0,
-            "Total Participants": 0,
-            "% Relevant Messages": None
+
+            "Total Messages": "-",  # Can't report this for individual weeks because the data has been overwritten with "STOP"
+            "Total Messages with Opt-Ins": len(AnalysisUtils.filter_opt_ins(messages, CONSENT_WITHDRAWN_KEY, [plan])),
+            "Total Relevant Messages": len(AnalysisUtils.filter_relevant(messages, CONSENT_WITHDRAWN_KEY, [plan])),
+
+            "Total Participants": "-",
+            "Total Participants with Opt-Ins": len(AnalysisUtils.filter_opt_ins(individuals, CONSENT_WITHDRAWN_KEY, [plan])),
+            "Total Relevant Participants": len(AnalysisUtils.filter_relevant(individuals, CONSENT_WITHDRAWN_KEY, [plan]))
         }
     engagement_counts["Total"] = {
         "Episode": "Total",
-        "Total Messages": 0,
-        "Relevant Messages": 0,
-        "Total Participants": 0,
-        "% Relevant Messages": None
+
+        "Total Messages": len(messages),
+        "Total Messages with Opt-Ins": len(AnalysisUtils.filter_opt_ins(messages, CONSENT_WITHDRAWN_KEY, PipelineConfiguration.RQA_CODING_PLANS)),
+        "Total Relevant Messages": len(AnalysisUtils.filter_relevant(messages, CONSENT_WITHDRAWN_KEY, PipelineConfiguration.RQA_CODING_PLANS)),
+
+        "Total Participants": len(individuals),
+        "Total Participants with Opt-Ins": len(AnalysisUtils.filter_opt_ins(individuals, CONSENT_WITHDRAWN_KEY, PipelineConfiguration.RQA_CODING_PLANS)),
+        "Total Relevant Participants": len(AnalysisUtils.filter_relevant(individuals, CONSENT_WITHDRAWN_KEY, PipelineConfiguration.RQA_CODING_PLANS))
     }
 
-    # Compute, per episode and across the season:
-    #  - Total Messages, by counting the number of consenting message objects that contain the raw_field key each week.
-    #  - Relevant Messages, by counting the number of consenting message objects which are coded with codes of type
-    #    CodeTypes.NORMAL. If a message was coded under multiple schemes, an additional assert is performed to ensure
-    #    the message was labelled with the same code type across all of those schemes.
-    for msg in messages:
-        if msg["consent_withdrawn"] == Codes.FALSE:
-            for plan in PipelineConfiguration.RQA_CODING_PLANS:
-                if plan.raw_field in msg:
-                    engagement_counts[plan.dataset_name]["Total Messages"] += 1
-                    engagement_counts["Total"]["Total Messages"] += 1
-
-                    # Get all the codes for this message under this code scheme
-                    codes = []
-                    for cc in plan.coding_configurations:
-                        if cc.coding_mode == CodingModes.SINGLE:
-                            codes.append(cc.code_scheme.get_code_with_code_id(msg[cc.coded_field]["CodeID"]))
-                        else:
-                            assert cc.coding_mode == CodingModes.MULTIPLE
-                            for label in msg[cc.coded_field]:
-                                codes.append(cc.code_scheme.get_code_with_code_id(label["CodeID"]))
-
-                    # Increment the count of relevant messages if the code is labelled with at least one normal code.
-                    code_types = [code.code_type for code in codes]
-                    if CodeTypes.NORMAL in code_types:
-                        engagement_counts[plan.dataset_name]["Relevant Messages"] += 1
-                        engagement_counts["Total"]["Relevant Messages"] += 1
-
-    # Compute, per episode and across the season:
-    #  - Total Participants, by counting the number of consenting individuals objects that contain the raw_field key
-    #    each week.
-    for ind in individuals:
-        if ind["consent_withdrawn"] == Codes.FALSE:
-            engagement_counts["Total"]["Total Participants"] += 1
-            for plan in PipelineConfiguration.RQA_CODING_PLANS:
-                if plan.raw_field in ind:
-                    engagement_counts[plan.dataset_name]["Total Participants"] += 1
-
-    # Compute:
-    #  - % Relevant Messages, by computing Relevant Messages / Total Messages * 100, to 1 decimal place.
-    for count in engagement_counts.values():
-        count["% Relevant Messages"] = round(count["Relevant Messages"] / count["Total Messages"] * 100, 1)
-
-    # Export the engagement counts to a csv.
     with open(f"{output_dir}/engagement_counts.csv", "w") as f:
-        headers = ["Episode", "Total Messages", "Relevant Messages", "% Relevant Messages", "Total Participants"]
+        headers = [
+            "Episode",
+            "Total Messages", "Total Messages with Opt-Ins", "Total Relevant Messages",
+            "Total Participants", "Total Participants with Opt-Ins", "Total Relevant Participants"
+        ]
         writer = csv.DictWriter(f, fieldnames=headers, lineterminator="\n")
         writer.writeheader()
 

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,4 +1,5 @@
 from .analysis_file import AnalysisFile
+from .analysis_utils import AnalysisUtils
 from .apply_manual_codes import ApplyManualCodes
 from .auto_code import AutoCode
 from .combine_raw_datasets import CombineRawDatasets

--- a/src/analysis_utils.py
+++ b/src/analysis_utils.py
@@ -1,0 +1,190 @@
+from core_data_modules.cleaners import Codes
+from core_data_modules.data_models.code_scheme import CodeTypes
+
+from src.lib.pipeline_configuration import CodingModes
+
+
+class AnalysisUtils(object):
+    @staticmethod
+    def _get_td_codes_for_coding_configuration(td, cc):
+        """
+        Returns all the codes from a TracedData object applied under the given coding configuration.
+
+        This is a helper method for many of the other methods in this class.
+        
+        :param td: TracedData to get the codes from.
+        :type td: TracedData
+        :param cc: Coding configuration.
+        :type cc: src.lib.pipeline_configuration.CodingConfiguration
+        :return: All the codes for the labels in the TracedData specified by the coding configuration `cc`.
+        :rtype: list of Code
+        """
+        if cc.coding_mode == CodingModes.SINGLE:
+            labels = [td[cc.coded_field]]
+        else:
+            assert cc.coding_mode == CodingModes.MULTIPLE
+            labels = td[cc.coded_field]
+
+        return [cc.code_scheme.get_code_with_code_id(label["CodeID"]) for label in labels]
+
+    @classmethod
+    def responded(cls, td, coding_plan):
+        """
+        Returns whether the given TracedData object contains a response to the given coding plan.
+
+        A response is any field that hasn't been labelled with either TRUE_MISSING or SKIPPED.
+        This includes participants who withdrew their consent to have their data analysed.
+
+        :param td: TracedData to check. 
+        :type td: TracedData
+        :param coding_plan: A coding plan specifying the field names to look up in `td`, and the code scheme to use
+                            to interpret those values.
+        :type coding_plan: src.lib.pipeline_configuration.CodingPlan
+        :return: Whether `td` contains a response to `coding_plan`.
+        :rtype: bool
+        """
+        for cc in coding_plan.coding_configurations:
+            codes = cls._get_td_codes_for_coding_configuration(td, cc)
+            assert len(codes) >= 1
+            if len(codes) > 1:
+                # If there is an NA or NS code, there shouldn't be any other codes present.
+                for code in codes:
+                    assert code.control_code != Codes.TRUE_MISSING and code.control_code != Codes.SKIPPED
+                return True
+            return codes[0].control_code != Codes.TRUE_MISSING and codes[0].control_code != Codes.SKIPPED
+
+    @staticmethod
+    def withdrew_consent(td, consent_withdrawn_key):
+        """
+        Returns whether the given TracedData object represents someone who withdrew their consent to have their data 
+        analysed.
+        
+        :param td: TracedData to check.
+        :type td: TracedData
+        :param consent_withdrawn_key: Key in the TracedData of the consent withdrawn field.
+        :type consent_withdrawn_key: str
+        :return: Whether consent was withdrawn.
+        :rtype: bool
+        """
+        return td[consent_withdrawn_key] == Codes.TRUE
+    
+    @classmethod
+    def opt_in(cls, td, consent_withdrawn_key, coding_plan):
+        """
+        Returns whether the given TracedData object contains a response to the given coding_plan.
+
+        A response is any field that hasn't been labelled with either TRUE_MISSING or SKIPPED.
+        Returns False for participants who withdrew their consent to have their data analysed.
+
+        :param td: TracedData to check.
+        :type td: TracedData
+        :param consent_withdrawn_key: Key in the TracedData of the consent withdrawn field.
+        :type consent_withdrawn_key: str
+        :param coding_plan: A coding plan specifying the field names to look up in `td`, and the code scheme to use
+                            to interpret those values.
+        :type coding_plan: src.lib.pipeline_configuration.CodingPlan
+        :return: Whether `td` contains a response to `coding_plan` and did not withdraw consent.
+        :rtype: bool
+        """
+        return not cls.withdrew_consent(td, consent_withdrawn_key) and cls.responded(td, coding_plan)
+
+    @classmethod
+    def relevant(cls, td, consent_withdrawn_key, coding_plan):
+        """
+        Returns whether the given TracedData object contains a relevant response to the given coding_plan.
+
+        A response is considered relevant if it is labelled with a normal code under any of its coding configurations.
+        Returns False for participants who withdrew their consent to have their data analysed.
+
+        :param td: TracedData to check.
+        :type td: TracedData
+        :param consent_withdrawn_key: Key in the TracedData of the consent withdrawn field.
+        :type consent_withdrawn_key: str
+        :param coding_plan: A coding plan specifying the field names to look up in `td`, and the code scheme to use
+                            to interpret those values.
+        :type coding_plan: src.lib.pipeline_configuration.CodingPlan
+        :return: Whether `td` contains a relevant response to `coding_plan`.
+        :rtype: bool
+        """
+        if cls.withdrew_consent(td, consent_withdrawn_key):
+            return False
+
+        for cc in coding_plan.coding_configurations:
+            codes = cls._get_td_codes_for_coding_configuration(td, cc)
+            for code in codes:
+                if code.code_type == CodeTypes.NORMAL:
+                    return True
+        return False
+    
+    @classmethod
+    def filter_responded(cls, data, coding_plans):
+        """
+        Filters a list of message or participant data for objects that responded to at least one of the given coding
+        plans.
+
+        For the definition of "responded", see `AnalysisUtils.responded`
+
+        :param data: Message or participant data to filter.
+        :type data: TracedData iterable
+        :param coding_plans: Coding plans specifying the fields in each TracedData object in `data` to look up.
+        :type coding_plans: list of src.lib.pipeline_configuration.CodingPlan
+        :return: data, filtered for only the objects that responded to at least one of the coding plans.
+        :rtype: list of TracedData
+        """
+        responded = []
+        for td in data:
+            for plan in coding_plans:
+                if cls.responded(td, plan):
+                    responded.append(td)
+                    break
+        return responded
+
+    @classmethod
+    def filter_opt_ins(cls, data, consent_withdrawn_key, coding_plans):
+        """
+        Filters a list of message or participant data for objects that opted-in and contained a response to at least
+        one of the given coding plans.
+
+        For the definition of "opted-in", see `AnalysisUtils.opt_in`
+
+        :param data: Message or participant data to filter.
+        :type data: TracedData iterable
+        :param consent_withdrawn_key: Key in the TracedData of the consent withdrawn field.
+        :type consent_withdrawn_key: str
+        :param coding_plans: Coding plans specifying the fields in each TracedData object in `data` to look up.
+        :type coding_plans: list of src.lib.pipeline_configuration.CodingPlan
+        :return: data, filtered for only the objects that opted-in and responded to at least one of the coding plans.
+        :rtype: list of TracedData
+        """
+        opt_ins = []
+        for td in data:
+            for plan in coding_plans:
+                if cls.opt_in(td, consent_withdrawn_key, plan):
+                    opt_ins.append(td)
+                    break
+        return opt_ins
+
+    @classmethod
+    def filter_relevant(cls, data, consent_withdrawn_key, coding_plans):
+        """
+        Filters a list of message or participant data for objects that are relevant to at least one of the given coding
+        plans.
+
+        For the definition of "relevant", see `AnalysisUtils.relevant`
+
+        :param data: Message or participant data to filter.
+        :type data: TracedData iterable
+        :param consent_withdrawn_key: Key in the TracedData of the consent withdrawn field.
+        :type consent_withdrawn_key: str
+        :param coding_plans: Coding plans specifying the fields in each TracedData object in `data` to look up.
+        :type coding_plans: list of src.lib.pipeline_configuration.CodingPlan
+        :return: data, filtered for only the objects that are relevant to at least one of the coding plans.
+        :rtype: list of TracedData
+        """
+        relevant = []
+        for td in data:
+            for plan in coding_plans:
+                if cls.relevant(td, consent_withdrawn_key, plan):
+                    relevant.append(td)
+                    break
+        return relevant


### PR DESCRIPTION
This contains standardised implementations of the terms defined here: https://docs.google.com/spreadsheets/d/1u2YnwIXA2OnaUV8Q8ivkCsK6VTJYKApZN4PXBzMnZvw/edit?folder=1QUv8T2KjTRKG9Xf10_GX0paQ29TlssNv#gid=0.

Moving the definitions to library functions ensures that we're using consistent terminology and consistent implementations throughout the automated analysis scripts. It should also make the analysis scripts shorter and more readable.

This PR also demonstrates usage of those standardised implementations by adapting the code that produces the engagement counts CSV to use them. Sample output here: https://drive.google.com/file/d/1nT7tDuIgZ9lskfVHOxdyHA9UuIHQYWY6/view?usp=sharing

I will adapt the remaining analysis code to use those implementations in a future PR if this one is approved. Note that not all of the cells in the analysis spec document linked above are being exported in the engagement counts CSV. I made a best guess based on my experience and conversations with others as to what was useful, which is all I can do until that document is fully reviewed.

@lukechurch requesting review for:
 - The outputted engagement_counts.csv.
 - The terminology and implementations used in analysis_utils.py.